### PR TITLE
Only run tests if mirage-block-unix is present

### DIFF
--- a/opam
+++ b/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-tar"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 dev-repo: "https://github.com/mirage/ocaml-tar.git"
 build: [
-["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{lwt:enable}%-lwtunix" "--%{mirage-types+io-page+ipaddr:enable}%-mirage" "--%{ounit:enable}%-tests" ]
+["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{lwt:enable}%-lwtunix" "--%{mirage-types+io-page+ipaddr:enable}%-mirage" "--%{ounit+mirage-block-unix:enable}%-tests" ]
   ["ocaml" "setup.ml" "-build"]
 ]
 build-test: [make "test"]


### PR DESCRIPTION
Fixes #12 
