### PR TITLE
Suppress a warching around catching `Failure` from `int_of_string`

### DIFF
--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -222,7 +222,7 @@ module Header = struct
     let tmp = "0o0" ^ (trim_numerical x) in
     try
       int_of_string tmp
-    with Failure "int_of_string" as e ->
+    with Failure _ as e ->
       Printf.eprintf "Failed to parse integer [%s] == %s\n" tmp (to_hex tmp);
       raise e
 


### PR DESCRIPTION
The intention here is to give better debugging output. It doesn't
really matter what the `x` is in `Failure x` since we know it comes
from `int_of_string`.

Signed-off-by: David Scott <dave@recoil.org>