### PR TITLE
add `mem` function & `Failure` error variant

### DIFF
--- a/lib/tar_mirage.ml
+++ b/lib/tar_mirage.ml
@@ -31,7 +31,7 @@ module Make_KV_RO (BLOCK : V1_LWT.BLOCK) = struct
   type id = BLOCK.id
   type 'a io = 'a Lwt.t
 
-  type error = Unknown_key of string
+  type error = Unknown_key of string | Failure of string
   type page_aligned_buffer = Cstruct.t
 
   (* Compare filenames without a leading / or ./ *)

--- a/lib/tar_mirage.ml
+++ b/lib/tar_mirage.ml
@@ -98,6 +98,9 @@ module Make_KV_RO (BLOCK : V1_LWT.BLOCK) = struct
 
   let disconnect _ = Lwt.return ()
 
+  let mem t key =
+    Lwt.return (`Ok (StringMap.mem key t.map))
+
   let read t key offset length =
     let key = trim_slash key in
     if not(StringMap.mem key t.map)


### PR DESCRIPTION
mirage/mirage#147 requests all implementors of `KV_RO` to provide a `mem` function. Add one, along with an error variant besides `Unknown_key` .