### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/lib/tar_mirage.ml
+++ b/lib/tar_mirage.ml
@@ -20,7 +20,7 @@ open Lwt.Infix
 
 module StringMap = Map.Make(String)
 
-module Make_KV_RO (BLOCK : V1_LWT.BLOCK) = struct
+module Make_KV_RO (BLOCK : Mirage_types_lwt.BLOCK) = struct
 
   type t = {
     b: BLOCK.t;

--- a/lib/tar_mirage.mli
+++ b/lib/tar_mirage.mli
@@ -16,11 +16,11 @@
 
 (** Tar for Mirage *)
 
-module Make_KV_RO (BLOCK : V1_LWT.BLOCK) : sig
+module Make_KV_RO (BLOCK : Mirage_types_lwt.BLOCK) : sig
   (** Construct a read-only key-value store from an existing block device
       containing tar-format data. *)
 
-  include V1_LWT.KV_RO
+  include Mirage_types_lwt.KV_RO
 
   val connect: BLOCK.t -> t Lwt.t
 end

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -143,7 +143,7 @@ module Block4096 = struct
 end
 
 module type BLOCK = sig
-  include V1_LWT.BLOCK
+  include Mirage_types_lwt.BLOCK
   val connect: string -> t Lwt.t
 end
 


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.