### PR TITLE
Disable some benign warnings.

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 true : color(always), bin_annot, principal
-true : warn(+A)
+true : warn(+A-44-41-32-26-27)
 true : package(cstruct result re re.str)
 "lib" : include
 


### PR DESCRIPTION
The build's currently rather noisy, due to lots of warnings.  A small sample:

```
Warning 44: this open statement shadows the value identifier pred (which is later used)
File "lib/tar_mirage.ml", line 114, characters 6-1337:
Warning 44: this open statement shadows the value identifier succ (which is later used)
File "lib/tar_mirage.ml", line 130, characters 29-85:
Warning 44: this open statement shadows the value identifier mul (which is later used)
File "lib/tar_mirage.ml", line 131, characters 61-125:
Warning 44: this open statement shadows the value identifier to_int (which is later used)
File "lib/tar_mirage.ml", line 131, characters 61-125:
Warning 44: this open statement shadows the value identifier sub (which is later used)
File "lib/tar_mirage.ml", line 131, characters 61-125:
```

This patch disables a few benign warnings in `_tags`