### PR TITLE
Mark some functions as @@ocaml.deprecated

### DIFF
--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -187,13 +187,13 @@ module Make (IO : IO) : sig
   end
 
   val write_block: ?level:Header.compatibility -> Header.t -> (IO.out_channel -> unit) -> IO.out_channel -> unit
-  (** [write_block hdr write_body fd] is DEPRECATED.
-      It writes [hdr], then calls [write_body fd] to write the body,
+    [@@ocaml.deprecated "Deprecated: use Tar.HeaderWriter"]
+  (** Write [hdr], then call [write_body fd] to write the body,
       then zero-pads so the stream is positioned for the next block. *)
 
   val write_end: IO.out_channel -> unit
-  (** [write_end fd] is DEPRECATED.
-      It writes a stream terminator to [fd]  *)
+    [@@ocaml.deprecated "Deprecated: use Tar.HeaderWriter"]
+  (** Writes a stream terminator to [fd]  *)
 
   module Archive : sig
     (** Utility functions for operating over whole tar archives *)
@@ -213,12 +213,12 @@ module Make (IO : IO) : sig
     (** Create a tar on file descriptor fd from the stream of headers.  *)
     val create_gen : ?level:Header.compatibility -> (Header.t * (IO.out_channel -> unit)) Stream.t -> IO.out_channel -> unit
 
-    (** This function is DEPRECATED.
-        [copy_n ifd odf n] copies exactly [n] bytes from [ifd] to [ofd] *)
+    (** [copy_n ifd odf n] copies exactly [n] bytes from [ifd] to [ofd] *)
     val copy_n : IO.in_channel -> IO.out_channel -> int64 -> unit
+      [@@ocaml.deprecated "Deprecated: use your own helper function"]
 
-    (** This function is DEPRECATED.
-        [skip fd n] reads and throws away [n] bytes from [fd] *)
+    (** [skip fd n] reads and throws away [n] bytes from [fd] *)
     val skip : IO.in_channel -> int -> unit
+      [@@ocaml.deprecated "Deprecated: use your own helper function"]
   end
 end

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -64,7 +64,7 @@ let rm_rf dir =
   loop dir
 
 let with_temp_dir f =
-  let dir = Filename.(concat temp_dir_name (Printf.sprintf "test.%d" (Unix.getpid()))) in
+  let dir = Filename.(concat (get_temp_dir_name ()) (Printf.sprintf "test.%d" (Unix.getpid()))) in
   Unix.mkdir dir 0o0755;
   finally (fun () -> f dir) (fun () -> rm_rf dir)
 

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -75,7 +75,6 @@ module Header = struct
     let file_mode = stat.Unix.LargeFile.st_perm in
     let user_id = stat.Unix.LargeFile.st_uid in
     let group_id = stat.Unix.LargeFile.st_gid in
-    let file_size = stat.Unix.LargeFile.st_size in
     let mod_time = Int64.of_float stat.Unix.LargeFile.st_mtime in
     let link_indicator = Link.Normal in
     let link_name = "" in

--- a/unix/tar_unix.mli
+++ b/unix/tar_unix.mli
@@ -38,13 +38,13 @@ module Header : sig
 end
 
 val write_block: ?level:Header.compatibility -> Header.t -> (Unix.file_descr -> unit) -> Unix.file_descr -> unit
-(** [write_block hdr write_body fd] is DEPRECATED.
-    It writes [hdr], then calls [write_body fd] to write the body,
-    then zero-pads so the stream is positioned for the next block. *)
+  [@@ocaml.deprecated "Deprecated in favor of Tar.HeaderWriter"]
+  (** Write [hdr], then call [write_body fd] to write the body,
+      then zero-pads so the stream is positioned for the next block. *)
 
 val write_end: Unix.file_descr -> unit
-(** [write_end fd] is DEPRECATED.
-    It writes a stream terminator to [fd]  *)
+  [@@ocaml.deprecated "Deprecated in favor of Tar.HeaderWriter"]
+  (** Write a stream terminator to [fd]  *)
 
 module Archive : sig
   (** Utility functions for operating over whole tar archives *)
@@ -64,19 +64,20 @@ module Archive : sig
   (** Create a tar on file descriptor fd from the filename list 'files' *)
   val create : string list -> Unix.file_descr -> unit
 
-  (** This function is DEPRECATED.
-      [copy_n ifd odf n] copies exactly [n] bytes from [ifd] to [ofd] *)
+  (** [copy_n ifd odf n] copies exactly [n] bytes from [ifd] to [ofd] *)
   val copy_n : Unix.file_descr -> Unix.file_descr -> int64 -> unit
+  [@@ocaml.deprecated "Deprecated: use your own helper function"]
 
-  (** This function is DEPRECATED.
-      [multicast_n ?buffer_size ifd ofds n] copies exactly [n] bytes from [ifd] to all [ofds] *)
+  (** [multicast_n ?buffer_size ifd ofds n] copies exactly [n] bytes from [ifd] to all [ofds] *)
   val multicast_n : ?buffer_size:int -> Unix.file_descr -> Unix.file_descr list -> int64 -> unit
+    [@@ocaml.deprecated "Deprecated: use your own helper function"]
 
-  (** This function is DEPRECATED.
-      [multicast_n_string buffer ofds n] copies [n] bytes from [buffer] to all [ofds] *)
+  (** [multicast_n_string buffer ofds n] copies [n] bytes from [buffer] to all [ofds] *)
   val multicast_n_string : string -> Unix.file_descr list -> int -> unit
+    [@@ocaml.deprecated "Deprecated: use your own helper function"]
 
-  (** This function is DEPRECATED.
-      [skip fd n] reads and throws away [n] bytes from [fd] *)
+  (** [skip fd n] reads and throws away [n] bytes from [fd] *)
   val skip : Unix.file_descr -> int -> unit
+    [@@ocaml.deprecated "Deprecated: use your own helper function"]
+
 end


### PR DESCRIPTION
Previously the functions were marked as deprecated in comments, but this isn't very obvious to users. This PR uses the new annotation.