### PR TITLE
Add basic Cstruct.t-backed tar processing

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,6 +1,7 @@
 (library
  ((name        tar)
   (public_name tar)
+  (wrapped false)
   (libraries   (result cstruct re.str))
   (preprocess (pps (cstruct.ppx)))
 ))

--- a/lib/tar_cstruct.ml
+++ b/lib/tar_cstruct.ml
@@ -1,0 +1,50 @@
+module Cstruct_io = struct
+  (* Input from a single Cstruct.t value *)
+
+  type in_channel = {
+    mutable pos : int;
+    data : Cstruct.t;
+  }
+
+  let make_in_channel data =
+    { pos = 0; data }
+
+  let check_available ch len =
+    min (Cstruct.len ch.data - ch.pos) len
+
+  let really_input ic buf pos len =
+    if check_available ic len <> len then raise End_of_file;
+    Cstruct.blit_to_bytes ic.data ic.pos buf pos len;
+    ic.pos <- ic.pos + len
+
+  let input ic buf pos len =
+    let available = check_available ic len in
+    Cstruct.blit_to_bytes ic.data ic.pos buf pos available;
+    ic.pos <- ic.pos + available;
+    available
+
+  (* Output to a list of Cstruct.t values *)
+
+  type out_channel = {
+    mutable data : Cstruct.t list;
+  }
+
+  let make_out_channel () = { data = [] }
+
+  let output oc buf pos len =
+    let elt = Cstruct.create len in
+    Cstruct.blit_from_string buf pos elt 0 len;
+    oc.data <- elt :: oc.data
+
+  let close_out (_ : out_channel) = ()
+
+  let to_string oc =
+    Cstruct.copyv (List.rev oc.data)
+
+  let to_cstruct oc =
+    Cstruct.concat (List.rev oc.data)
+end
+
+include Cstruct_io
+
+include Tar.Make(Cstruct_io)

--- a/lib/tar_cstruct.mli
+++ b/lib/tar_cstruct.mli
@@ -1,0 +1,46 @@
+(** {1 Processing tar content with cstruct buffers} *)
+
+type in_channel
+type out_channel
+
+val make_in_channel : Cstruct.t -> in_channel
+(** [make_in_channel buf] uses [buf] as a source of raw tar content. *)
+
+val make_out_channel : unit -> out_channel
+(** [make_out_channel ()] returns a buffer to hold serialized tar content. *)
+
+val to_string : out_channel -> string
+(** [to_string oc] returns the contents of [oc] as a string of bytes. *)
+
+val to_cstruct : out_channel -> Cstruct.t
+(** [to_cstruct oc] returns the contents of [oc] as a {!Cstruct.t}. *)
+
+val really_read : in_channel -> Cstruct.t -> unit
+(** [really_read ic buf] fills [buf] with data from [ic] or raises
+    {!Pervasives.End_of_file *)
+
+val really_write : out_channel -> Cstruct.t -> unit
+(** [really_write oc buf] writes the full contents of [buf] to [oc]
+    or raises End_of_file *)
+
+module Header : sig
+  include module type of Tar.Header
+
+  val get_next_header : ?level:compatibility -> in_channel -> t
+  (** [get_next_header ?level ic] returns the next header block or fails with
+      `Eof if two consecutive zero-filled blocks are discovered. Assumes [ic]
+      is positioned at the possible start of a header block. End_of_file is
+      thrown if the stream unexpectedly fails *)
+end
+
+module Archive : sig
+  val with_next_file : in_channel -> (in_channel -> Header.t -> 'a) -> 'a
+  (** [with_next_file ic f] Read the next header, apply the function [f] to
+      [ic] and the header.  The function should leave [ic] positioned
+      immediately after the datablock.  {!really_read} can be used for this
+      purpose. Finally the function skips past the zero padding to the next
+      header *)
+
+  val list : ?level:Header.compatibility -> in_channel -> Header.t list
+  (** List the contents of a tar *)
+end


### PR DESCRIPTION
This PR adds a `Tar_cstruct` module to the main `tar` package.  The focus is on reading tar content but `Tar_cstruct.Cstruct_io` should have most or all of what is required for writing as well.

This at least partially addresses #36 so I'm putting it up for comment/consideration.