### PR TITLE
Fix build with OCaml 4.06 (and -safe-string)

### DIFF
--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -161,9 +161,9 @@ module type IO = sig
   type in_channel
   type out_channel
 
-  val really_input : in_channel -> string -> int -> int -> unit
-  val input : in_channel -> string -> int -> int -> int
-  val output : out_channel -> string -> int -> int -> unit
+  val really_input : in_channel -> bytes -> int -> int -> unit
+  val input : in_channel -> bytes -> int -> int -> int
+  val output : out_channel -> bytes -> int -> int -> unit
   val close_out : out_channel -> unit
 end
 

--- a/lib/tar_cstruct.ml
+++ b/lib/tar_cstruct.ml
@@ -33,7 +33,7 @@ module Cstruct_io = struct
 
   let output oc buf pos len =
     let elt = Cstruct.create len in
-    Cstruct.blit_from_string buf pos elt 0 len;
+    Cstruct.blit_from_bytes buf pos elt 0 len;
     oc.data <- elt :: oc.data
 
   let close_out (_ : out_channel) = ()

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -207,10 +207,10 @@ module Test(B: BLOCK) = struct
                   finally
                     (fun () ->
                        let (_: int) = Unix.lseek fd ofs Unix.SEEK_SET in
-                       let buf = String.make len '\000' in
+                       let buf = Bytes.make len '\000' in
                        let len' = Unix.read fd buf 0 len in
                        assert_equal ~printer:string_of_int len len';
-                       buf
+                       Bytes.to_string buf
                     ) (fun () -> Unix.close fd) in
                 let read_tar key ofs len =
                   KV_RO.read k key ofs len

--- a/tar.opam
+++ b/tar.opam
@@ -19,6 +19,7 @@ depends: [
   "jbuilder"          {build}
   "ocamlfind"         {build}
   "ppx_tools"         {build}
+  "ppx_cstruct"       {build}
   "cstruct"           {>= "1.9.0"}
   "re"
   "result"

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -126,18 +126,15 @@ module Archive = struct
   (** Multicast 'n' bytes from input fd 'ifd' to output fds 'ofds'. NB if one deadlocks
       they all stop.*)
   let multicast_n ?(buffer_size=1024*1024) (ifd: Unix.file_descr) (ofds: Unix.file_descr list) (n: int64) =
-    let buffer = String.make buffer_size '\000' in
+    let buffer = Bytes.make buffer_size '\000' in
     let rec loop (n: int64) =
       if n <= 0L then ()
       else
-        let amount = Int64.to_int (min n (Int64.of_int(String.length buffer))) in
+        let amount = Int64.to_int (min n (Int64.of_int(Bytes.length buffer))) in
         let read = Unix.read ifd buffer 0 amount in
         if read = 0 then raise End_of_file;
         List.iter (fun ofd -> ignore(Unix.write ofd buffer 0 read)) ofds;
         loop (Int64.sub n (Int64.of_int read)) in
     loop n
-
-  let multicast_n_string buffer ofds n =
-    List.iter (fun ofd -> ignore(Unix.write ofd buffer 0 n)) ofds
 
 end

--- a/unix/tar_unix.mli
+++ b/unix/tar_unix.mli
@@ -72,10 +72,6 @@ module Archive : sig
   val multicast_n : ?buffer_size:int -> Unix.file_descr -> Unix.file_descr list -> int64 -> unit
     [@@ocaml.deprecated "Deprecated: use your own helper function"]
 
-  (** [multicast_n_string buffer ofds n] copies [n] bytes from [buffer] to all [ofds] *)
-  val multicast_n_string : string -> Unix.file_descr list -> int -> unit
-    [@@ocaml.deprecated "Deprecated: use your own helper function"]
-
   (** [skip fd n] reads and throws away [n] bytes from [fd] *)
   val skip : Unix.file_descr -> int -> unit
     [@@ocaml.deprecated "Deprecated: use your own helper function"]


### PR DESCRIPTION
Note this uses `bytes` rather than `string` as a buffer and this
patch also removes the deprecated function `multicast_n_string`

Signed-off-by: David Scott <dave@recoil.org>