### PR TITLE
README.md: fix the package name and link to `tar.opam`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## tar-format -- decode and encode tar files
+## tar -- decode and encode tar files
 
-tar-format is a simple library to read and write tar files with an emphasis on
+tar is a simple library to read and write tar files with an emphasis on
 streaming.
 
 This is pure OCaml code, no C bindings.
@@ -43,9 +43,9 @@ This library is used by
 
 ## Installation
 
-`tar-format` can be installed with `opam`:
+`tar` can be installed with `opam`:
 
-    opam install tar-format
+    opam install tar
 
 If you don't use `opam` consult the [`opam`](opam) file for build
 instructions.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This library is used by
 
     opam install tar
 
-If you don't use `opam` consult the [`opam`](opam) file for build
+If you don't use `opam` consult the [`tar.opam`](tar.opam) file for build
 instructions.
 
 ### Documentation


### PR DESCRIPTION
- the library formerly known as `tar-format` was renamed to `tar`
- the `opam` file is now `tar.opam`