### PR TITLE
Use `ppx_cstruct` rather than the old name `cstruct.ppx`

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -4,5 +4,5 @@
   (wrapped false)
   (libraries   (result cstruct re.str))
   (flags (:standard -safe-string))
-  (preprocess (pps (cstruct.ppx)))
+  (preprocess (pps (ppx_cstruct)))
 ))


### PR DESCRIPTION
The old name only works via the `META` file, which doesn't work if
building in a single jbuilder workspace.

Signed-off-by: David Scott <dave@recoil.org>