### PR TITLE
Do not suppress "unused value" warning

### DIFF
--- a/tar.opam
+++ b/tar.opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
   "ppx_tools" {build}
-  "ppx_cstruct" {>= "3.1.0"}
+  "ppx_cstruct" {>= "3.6.0"}
   "cstruct" {>= "1.9.0"}
   "re"
   "result"


### PR DESCRIPTION
Hi,

`ppx_cstruct.3.6.0` now silences warnings in generated code, so we can remove the suppression and find some dead code.

Two remarks:
- `sizeof` is not ignored (mirage/ocaml-cstruct#231), but it seems to be common to add an assert in this case.
- `to_detailed_string` could also be exposed in the interface, but since it's been hidden since 2+ years and nobody complained, it seems that it can go away :slightly_smiling_face: 

What do you think? Thanks!