### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -7,7 +7,7 @@ doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "tar"
   "cstruct" {>= "1.9.0"}
   "re" {>="1.7.2"}

--- a/tar-unix.opam
+++ b/tar-unix.opam
@@ -7,7 +7,7 @@ doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "tar"
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"

--- a/tar.opam
+++ b/tar.opam
@@ -7,7 +7,7 @@ doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ppx_tools" {build}
   "ppx_cstruct" {>= "3.6.0"}
   "cstruct" {>= "1.9.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.