### PR TITLE
Fix Dune 2.9 --root .

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 2.9)
 (name tar)
 
+(formatting disabled)
 (generate_opam_files true)
 
 (source (github mirage/ocaml-tar))

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -31,7 +31,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/tar-unix.opam
+++ b/tar-unix.opam
@@ -23,7 +23,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/tar.opam
+++ b/tar.opam
@@ -23,7 +23,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
Will be fixed in Dune 2.9.1, no need for a .opam.template.