### PR TITLE
Remove Header module from the functor and use only Tar.Header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,16 @@
 - Bump lower-bound on Cstruct to 6.0.0 (@MisterDA)
 - Update to Dune 2.9 and generate opam files (@MisterDA)
 - Don't print the name of the file in extract functions (@MisterDA)
+- Remove Tar.Make.Header, Tar_cstruct.Header, Tar_unix.Header, and
+  Tar_lwt_unix.Header to keep only Tar.Header and use it everywhere.
+  - Tar.Make.Header.get_next_header becomes Tar.Make.get_next_header;
+  - Tar_cstruct.Header.get_next_header becomes Tar_cstruct.get_next_header;
+  - Tar_lwt_unix.Header.get_next_header becomes Tar_lwt_unix.get_next_header;
+  - Tar_lwt_unix.Header.of_file becomes Tar_lwt_unix.header_of_file;
+  - Tar_unix.Header.get_next_header becomes Tar_unix.get_next_header;
+  - Tar_unix.Header.of_file becomes Tar_unix.header_of_file;
+  - All the Tar_*.Header.t values have to be changed to Tar.Header.t.
+  (@MisterDA)
 
 ## v1.1.0 (2019-04-08)
 

--- a/README.md
+++ b/README.md
@@ -27,23 +27,23 @@ utop # let f = Lwt_unix.openfile "/tmp/foo.tar" [ Unix.O_RDONLY ] 0;;
 val f : Lwt_unix.file_descr = <abstr>
 
 utop # Lwt.bind f Tar_lwt_unix.Archive.list;;
-[{Tar_lwt_unix.Header.file_name = "_build/lib/tar.mli.depends";
-  Tar_lwt_unix.Header.file_mode = 420; Tar_lwt_unix.Header.user_id = 1000;
-  Tar_lwt_unix.Header.group_id = 1000; Tar_lwt_unix.Header.file_size = 21L;
-  Tar_lwt_unix.Header.mod_time = 1381080315L;
-  Tar_lwt_unix.Header.link_indicator = Tar_lwt_unix.Header.Link.Normal;
-  Tar_lwt_unix.Header.link_name = ""};
- {Tar_lwt_unix.Header.file_name = "_build/lib/tar_unix.mli.depends";
-  Tar_lwt_unix.Header.file_mode = 420; Tar_lwt_unix.Header.user_id = 1000;
-  Tar_lwt_unix.Header.group_id = 1000; Tar_lwt_unix.Header.file_size = 27L;
-  Tar_lwt_unix.Header.mod_time = 1381080318L;
-  Tar_lwt_unix.Header.link_indicator = Tar_lwt_unix.Header.Link.Normal;
-  Tar_lwt_unix.Header.link_name = ""};
- {Tar_lwt_unix.Header.file_name = "_build/lib/tar.mllib";
-  Tar_lwt_unix.Header.file_mode = ...; Tar_lwt_unix.Header.user_id = ...;
-  Tar_lwt_unix.Header.group_id = ...; Tar_lwt_unix.Header.file_size = ...;
-  Tar_lwt_unix.Header.mod_time = ...; Tar_lwt_unix.Header.link_indicator = ...;
-  Tar_lwt_unix.Header.link_name = ...};
+[{Tar.Header.file_name = "_build/lib/tar.mli.depends";
+  Tar.Header.file_mode = 420; Tar.Header.user_id = 1000;
+  Tar.Header.group_id = 1000; Tar.Header.file_size = 21L;
+  Tar.Header.mod_time = 1381080315L;
+  Tar.Header.link_indicator = Tar.Header.Link.Normal;
+  Tar.Header.link_name = ""};
+ {Tar.Header.file_name = "_build/lib/tar_unix.mli.depends";
+  Tar.Header.file_mode = 420; Tar.Header.user_id = 1000;
+  Tar.Header.group_id = 1000; Tar.Header.file_size = 27L;
+  Tar.Header.mod_time = 1381080318L;
+  Tar.Header.link_indicator = Tar.Header.Link.Normal;
+  Tar.Header.link_name = ""};
+ {Tar.Header.file_name = "_build/lib/tar.mllib";
+  Tar.Header.file_mode = ...; Tar.Header.user_id = ...;
+  Tar.Header.group_id = ...; Tar.Header.file_size = ...;
+  Tar.Header.mod_time = ...; Tar.Header.link_indicator = ...;
+  Tar.Header.link_name = ...};
  ...]
 ```
 

--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -740,6 +740,10 @@ module Make (IO : IO) = struct
 
   module HR = HeaderReader(Direct)(Reader)
 
+  let get_next_header ?level ic = match HR.read ?level ic with
+    | Ok hdr -> hdr
+    | Error `Eof -> raise Header.End_of_stream
+
   (** Utility functions for operating over whole tar archives *)
   module Archive = struct
 
@@ -818,15 +822,6 @@ module Make (IO : IO) = struct
       Stream.iter file files;
       (* Add two empty blocks *)
       write_end ofd
-
-  end
-
-  module Header = struct
-    include Header
-
-    let get_next_header ?level ic = match HR.read ?level ic with
-      | Ok hdr -> hdr
-      | Error `Eof -> raise Header.End_of_stream
 
   end
 end

--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -177,15 +177,11 @@ module Make (IO : IO) : sig
   (** [really_write fd buf] writes the full contents of [buf] to [fd]
       or raises {!Stdlib.End_of_file}. *)
 
-  module Header : sig
-    include module type of Header
-
-    (** Returns the next header block or fails with [`Eof] if two consecutive
-        zero-filled blocks are discovered. Assumes stream is positioned at the
-        possible start of a header block.
-        @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
-    val get_next_header : ?level:compatibility -> IO.in_channel -> t
-  end
+  (** Returns the next header block or fails with [`Eof] if two consecutive
+      zero-filled blocks are discovered. Assumes stream is positioned at the
+      possible start of a header block.
+      @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
+  val get_next_header : ?level:Header.compatibility -> IO.in_channel -> Header.t
 
   val write_block: ?level:Header.compatibility -> Header.t -> (IO.out_channel -> unit) -> IO.out_channel -> unit
     [@@ocaml.deprecated "Deprecated: use Tar.HeaderWriter"]

--- a/lib/tar_cstruct.mli
+++ b/lib/tar_cstruct.mli
@@ -23,24 +23,20 @@ val really_write : out_channel -> Cstruct.t -> unit
 (** [really_write oc buf] writes the full contents of [buf] to [oc]
     or raises {!Stdlib.End_of_file}. *)
 
-module Header : sig
-  include module type of Tar.Header
-
-  val get_next_header : ?level:compatibility -> in_channel -> t
-  (** [get_next_header ?level ic] returns the next header block or fails with
-      [`Eof] if two consecutive zero-filled blocks are discovered. Assumes [ic]
-      is positioned at the possible start of a header block.
-      @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
-end
+val get_next_header : ?level:Tar.Header.compatibility -> in_channel -> Tar.Header.t
+(** [get_next_header ?level ic] returns the next header block or fails with
+    [`Eof] if two consecutive zero-filled blocks are discovered. Assumes [ic]
+    is positioned at the possible start of a header block.
+    @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
 
 module Archive : sig
-  val with_next_file : in_channel -> (in_channel -> Header.t -> 'a) -> 'a
+  val with_next_file : in_channel -> (in_channel -> Tar.Header.t -> 'a) -> 'a
   (** [with_next_file ic f] Read the next header, apply the function [f] to
       [ic] and the header.  The function should leave [ic] positioned
       immediately after the datablock. {!really_read} can be used for this
       purpose. Finally the function skips past the zero padding to the next
       header. *)
 
-  val list : ?level:Header.compatibility -> in_channel -> Header.t list
+  val list : ?level:Tar.Header.compatibility -> in_channel -> Tar.Header.t list
   (** List the contents of a tar. *)
 end

--- a/unix/tar_unix.mli
+++ b/unix/tar_unix.mli
@@ -24,20 +24,16 @@ val really_write: Unix.file_descr -> Cstruct.t -> unit
 (** [really_write fd buf] writes the full contents of [buf] to [fd]
     or {!Stdlib.End_of_file}. *)
 
-module Header : sig
-  include module type of Tar.Header
+(** Returns the next header block or throws End_of_stream if two consecutive
+    zero-filled blocks are discovered. Assumes stream is positioned at the
+    possible start of a header block.
+    @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
+val get_next_header : ?level:Tar.Header.compatibility -> Unix.file_descr -> Tar.Header.t
 
-  (** Returns the next header block or throws End_of_stream if two consecutive
-      zero-filled blocks are discovered. Assumes stream is positioned at the
-      possible start of a header block.
-      @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
-  val get_next_header : ?level:compatibility -> Unix.file_descr -> t
+(** Return the header needed for a particular file on disk. *)
+val header_of_file : ?level:Tar.Header.compatibility -> string -> Tar.Header.t
 
-  (** Return the header needed for a particular file on disk. *)
-  val of_file : ?level:compatibility -> string -> t
-end
-
-val write_block: ?level:Header.compatibility -> Header.t -> (Unix.file_descr -> unit) -> Unix.file_descr -> unit
+val write_block: ?level:Tar.Header.compatibility -> Tar.Header.t -> (Unix.file_descr -> unit) -> Unix.file_descr -> unit
   [@@ocaml.deprecated "Deprecated in favor of Tar.HeaderWriter"]
   (** Write [hdr], then call [write_body fd] to write the body,
       then zero-pads so the stream is positioned for the next block. *)
@@ -52,10 +48,10 @@ module Archive : sig
   (** Read the next header, apply the function 'f' to the fd and the header. The function
       should leave the fd positioned immediately after the datablock. Finally the function
       skips past the zero padding to the next header. *)
-  val with_next_file : Unix.file_descr -> (Unix.file_descr -> Header.t -> 'a) -> 'a
+  val with_next_file : Unix.file_descr -> (Unix.file_descr -> Tar.Header.t -> 'a) -> 'a
 
   (** List the contents of a tar. *)
-  val list : ?level:Header.compatibility -> Unix.file_descr -> Header.t list
+  val list : ?level:Tar.Header.compatibility -> Unix.file_descr -> Tar.Header.t list
 
   (** [extract dest] extract the contents of a tar.
       Apply [dest] on each source filename to change the destination filename. *)


### PR DESCRIPTION
The Header module doesn't depend on anything in the Tar.Make functor,
as it has nothing to do with IO but simply to map the tar header to an
OCaml record type and associated helper functions.

Removing it from the functor helps cleaning the code an sharing the
header type definition between different IO backends.