### PR TITLE
Code cleanups, bugfixes, and modern APIs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tar	binary

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   - Tar_unix.Header.of_file becomes Tar_unix.header_of_file;
   - All the Tar_*.Header.t values have to be changed to Tar.Header.t.
   (@MisterDA)
+- Fix parsing of pax Extended Header File Times with sub-second
+  granularity. (@MisterDA)
 
 ## v1.1.0 (2019-04-08)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 - Bump lower-bound on Cstruct to 6.0.0 (@MisterDA)
 - Update to Dune 2.9 and generate opam files (@MisterDA)
 - Support only OCaml versions 4.08 and higher. (@MisterDA)
-- Don't print the name of the file in extract functions (@MisterDA)
+- Don't print any logging to stdout or stderr (@MisterDA)
 - Remove Tar.Make.Header, Tar_cstruct.Header, Tar_unix.Header, and
   Tar_lwt_unix.Header to keep only Tar.Header and use it everywhere.
   - Tar.Make.Header.get_next_header becomes Tar.Make.get_next_header;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
   (@MisterDA)
 - Fix parsing of pax Extended Header File Times with sub-second
   granularity. (@MisterDA)
+- Add Tar_unix.transform and Tar_lwt_unix.transform to help
+  transforming headers of a streamed tar archive between two file
+  descriptors. (@MisterDA)
 
 ## v1.1.0 (2019-04-08)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - Bump lower-bound on Cstruct to 6.0.0 (@MisterDA)
 - Update to Dune 2.9 and generate opam files (@MisterDA)
+- Support only OCaml versions 4.08 and higher. (@MisterDA)
 - Don't print the name of the file in extract functions (@MisterDA)
 - Remove Tar.Make.Header, Tar_cstruct.Header, Tar_unix.Header, and
   Tar_lwt_unix.Header to keep only Tar.Header and use it everywhere.

--- a/dune-project
+++ b/dune-project
@@ -73,6 +73,7 @@
   (io-page-unix :with-test)
   (mirage-block-unix (and :with-test (>= 2.5.0)))
   (ounit2 :with-test)
+  (ounit2-lwt :with-test)
   (tar-unix (and :with-test (= :version)))
  )
 )

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
  )
  (tags ("org:xapi-project" "org:mirage"))
  (depends
-  (ocaml (>= 4.03.0))
+  (ocaml (>= 4.08.0))
   (ppx_cstruct (and :build (>= 3.6.0)))
   (cstruct (>= 6.0.0))
   re
@@ -61,7 +61,7 @@
  )
  (tags ("org:xapi-project" "org:mirage"))
  (depends
-  (ocaml (>= 4.05.0))
+  (ocaml (>= 4.08.0))
   (cstruct (>= 1.9.0))
   io-page
   lwt

--- a/dune-project
+++ b/dune-project
@@ -10,6 +10,7 @@
  "Dave Scott"
  "Thomas Gazagnaire"
  "David Allsopp"
+ "Antonin Décimo"
 )
 (maintainers "dave@recoil.org")
 (documentation "https://mirage.github.io/ocaml-tar/")

--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -40,9 +40,8 @@ module Header = struct
     let tmp = "0o0" ^ (trim_numerical x) in
     try
       int_of_string tmp
-    with Failure _ as e ->
-      Printf.eprintf "Failed to parse integer [%s] == %s\n" tmp (to_hex tmp);
-      raise e
+    with Failure msg ->
+      failwith (Printf.sprintf "%s: failed to parse integer [%s] == %s" msg tmp (to_hex tmp))
 
   (** Unmarshal an int64 field (stored as 0-padded octal) *)
   let unmarshal_int64 (x: string) : int64 =

--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -51,14 +51,14 @@ module Header : sig
 
   module Extended: sig
     type t = {
-      access_time: int64 option;
+      access_time: int64 option; (** second granularity since the Epoch *)
       charset: string option;
       comment: string option;
       group_id: int option;
       gname: string option;
       header_charset: string option;
       link_path: string option;
-      mod_time: int64 option;
+      mod_time: int64 option; (** second granularity since the Epoch *)
       path: string option;
       file_size: int64 option;
       user_id: int option;

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,19 +1,12 @@
-(executables
+(tests
  (names parse_test)
- (flags :standard -safe-string)
+ (package tar-mirage)
  (libraries
   mirage-block-unix
   mirage-block
   ounit2
+  ounit2-lwt
   lwt
   io-page-unix
   tar-unix
   tar-mirage))
-
-(rule
- (alias runtest)
- (package tar-mirage)
- (deps
-  (:< parse_test.exe))
- (action
-  (run %{<})))

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -99,7 +99,7 @@ let can_write_pax _test_ctxt =
   with_temp_file
     (fun filename ->
       (* This userid is too large for a regular ustar header *)
-      let user_id = 2116562692 in
+      let user_id = 0x07777777 + 1 in
       (* Write a file which would need a pax header *)
       let fd = Unix.openfile filename [ Unix.O_CREAT; Unix.O_WRONLY ] 0o0644 in
       Fun.protect

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -220,8 +220,8 @@ module Test(B: BLOCK) = struct
                   read_tar (Mirage_kv.Key.v file) >>= fun value' ->
                   let value'' = String.sub value' 1 ((Int64.to_int size) - 2) in
                   assert_equal ~printer:(fun x -> x) value value'';
-                  Lwt.return ()
-                end else Lwt.return ()
+                  Lwt.return_unit
+                end else Lwt.return_unit
              ) files in
          Lwt_main.run t
       )

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -15,7 +15,7 @@
 [@@@warning "-3-27"] (* FIXME: deprecation from the tar library *)
 
 open OUnit
-open Lwt
+open Lwt.Infix
 
 exception Cstruct_differ
 
@@ -151,7 +151,7 @@ module Block4096 = struct
     Block.get_info b
     >>= fun info ->
     let size_sectors = Int64.(div (add info.size_sectors 7L) 8L) in
-    return { info with Mirage_block.sector_size = 4096; size_sectors }
+    Lwt.return { info with Mirage_block.sector_size = 4096; size_sectors }
 
   let read b ofs bufs =
     Block.get_info b
@@ -209,7 +209,7 @@ module Test(B: BLOCK) = struct
                 let read_tar key =
                   KV_RO.get k key >>= function
                   | Error _ -> failwith "KV_RO.read"
-                  | Ok buf -> return buf in
+                  | Ok buf -> Lwt.return buf in
                 (* Read whole file *)
                 let size = stats.Unix.LargeFile.st_size in
                 let value = read_file file 0 (Int64.to_int size) in
@@ -220,8 +220,8 @@ module Test(B: BLOCK) = struct
                   read_tar (Mirage_kv.Key.v file) >>= fun value' ->
                   let value'' = String.sub value' 1 ((Int64.to_int size) - 2) in
                   assert_equal ~printer:(fun x -> x) value value'';
-                  return ()
-                end else return ()
+                  Lwt.return ()
+                end else Lwt.return ()
              ) files in
          Lwt_main.run t
       )

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -14,7 +14,7 @@
 
 [@@@warning "-3-27"] (* FIXME: deprecation from the tar library *)
 
-open OUnit
+open OUnit2
 open Lwt.Infix
 
 exception Cstruct_differ
@@ -31,7 +31,7 @@ let cstruct_equal a b =
     with _ -> false in
   (Cstruct.length a = (Cstruct.length b)) && (check_contents a b)
 
-let header () =
+let header _test_ctxt =
   (* check header marshalling and unmarshalling *)
   let h = Tar.Header.make ~file_mode:5 ~user_id:1001 ~group_id:1002 ~mod_time:55L ~link_name:"" "hello" 1234L in
   let txt = "hello\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\0000000005\0000001751\0000001752\00000000002322\00000000000067\0000005534\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000" in
@@ -86,7 +86,7 @@ let with_tar ?files f =
       f tar_filename files
     )
 
-let can_read_tar () =
+let can_read_tar _test_ctxt =
   with_tar
     (fun tar_filename files ->
        let fd = Unix.openfile tar_filename [ Unix.O_RDONLY ] 0 in
@@ -98,7 +98,7 @@ let can_read_tar () =
        assert_equal ~printer:(String.concat "; ") [] missing'
     )
 
-let can_write_pax () =
+let can_write_pax _test_ctxt =
   let open Tar_unix in
   with_temp_file
     (fun filename ->
@@ -125,7 +125,7 @@ let can_write_pax () =
         ) (fun () -> Unix.close fd);
     )
 
-let can_list_longlink_tar () =
+let can_list_longlink_tar _test_ctxt =
   let open Tar_unix in
   with_temp_dir
     (fun dir ->
@@ -140,7 +140,7 @@ let can_list_longlink_tar () =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/BCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/";
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/BCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/CDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.txt";
           ] in
-          OUnit.assert_equal ~printer:(String.concat ", ") expected filenames
+          assert_equal ~printer:(String.concat ", ") expected filenames
         ) (fun () -> Unix.close fd);
     )
 
@@ -186,46 +186,45 @@ module B = struct
 end
 
 module Test(B: BLOCK) = struct
-  let can_read_through_BLOCK ?files () =
+  let can_read_through_BLOCK ?files _test_ctxt =
     with_tar ?files
       (fun tar_filename files ->
-         let t =
-           B.connect tar_filename >>= fun b ->
-           let module KV_RO = Tar_mirage.Make_KV_RO(B) in
-           KV_RO.connect b >>= fun k ->
-           Lwt_list.iter_s
-             (fun file ->
-                let stats = Unix.LargeFile.stat file in
-                let read_file key ofs len =
-                  let fd = Unix.openfile key [ Unix.O_RDONLY ] 0 in
-                  finally
-                    (fun () ->
-                       let (_: int) = Unix.lseek fd ofs Unix.SEEK_SET in
-                       let buf = Bytes.make len '\000' in
-                       let len' = Unix.read fd buf 0 len in
-                       assert_equal ~printer:string_of_int len len';
-                       Bytes.to_string buf
-                    ) (fun () -> Unix.close fd) in
-                let read_tar key =
-                  KV_RO.get k key >>= function
-                  | Error _ -> failwith "KV_RO.read"
-                  | Ok buf -> Lwt.return buf in
-                (* Read whole file *)
-                let size = stats.Unix.LargeFile.st_size in
-                let value = read_file file 0 (Int64.to_int size) in
+         B.connect tar_filename >>= fun b ->
+         let module KV_RO = Tar_mirage.Make_KV_RO(B) in
+         KV_RO.connect b >>= fun k ->
+         Lwt_list.iter_s
+           (fun file ->
+              let stats = Unix.LargeFile.stat file in
+              let read_file key ofs len =
+                let fd = Unix.openfile key [ Unix.O_RDONLY ] 0 in
+                finally
+                  (fun () ->
+                     let (_: int) = Unix.lseek fd ofs Unix.SEEK_SET in
+                     let buf = Bytes.make len '\000' in
+                     let len' = Unix.read fd buf 0 len in
+                     assert_equal ~printer:string_of_int len len';
+                     Bytes.to_string buf
+                  ) (fun () -> Unix.close fd) in
+              let read_tar key =
+                KV_RO.get k key >>= function
+                | Error _ -> failwith "KV_RO.read"
+                | Ok buf -> Lwt.return buf in
+              (* Read whole file *)
+              let size = stats.Unix.LargeFile.st_size in
+              let value = read_file file 0 (Int64.to_int size) in
+              read_tar (Mirage_kv.Key.v file) >>= fun value' ->
+              assert_equal ~printer:(fun x -> x) value value';
+              if Int64.compare size 2L = 1 then begin
+                let value = read_file file 1 ((Int64.to_int size) - 2) in
                 read_tar (Mirage_kv.Key.v file) >>= fun value' ->
-                assert_equal ~printer:(fun x -> x) value value';
-                if Int64.compare size 2L = 1 then begin
-                  let value = read_file file 1 ((Int64.to_int size) - 2) in
-                  read_tar (Mirage_kv.Key.v file) >>= fun value' ->
-                  let value'' = String.sub value' 1 ((Int64.to_int size) - 2) in
-                  assert_equal ~printer:(fun x -> x) value value'';
-                  Lwt.return_unit
-                end else Lwt.return_unit
-             ) files in
-         Lwt_main.run t
+                let value'' = String.sub value' 1 ((Int64.to_int size) - 2) in
+                assert_equal ~printer:(fun x -> x) value value'';
+                Lwt.return_unit
+              end else Lwt.return_unit
+           ) files
       )
-    let check_not_padded () =
+
+    let check_not_padded _test_ctxt =
       ignore (Unix.openfile "empty" [ Unix.O_CREAT; Unix.O_TRUNC ] 0o0644);
       can_read_through_BLOCK ~files:["empty"] ()
 end
@@ -233,22 +232,17 @@ end
 module Sector512 = Test(B)
 module Sector4096 = Test(Block4096)
 
-let _ =
-  let verbose = ref false in
-  Arg.parse [
-    "-verbose", Arg.Unit (fun _ -> verbose := true), "Run in verbose mode";
-  ] (fun x -> Printf.fprintf stderr "Ignoring argument: %s" x)
-    "Test tar parser";
+let () =
   let suite = "tar" >:::
               [
                 "header" >:: header;
                 "can_read_tar" >:: can_read_tar;
-                "can_read_through_BLOCK/512" >:: Sector512.can_read_through_BLOCK;
-                "not 4KiB padded" >:: Sector512.check_not_padded;
-                "can_read_through_BLOCK/4096" >:: Sector4096.can_read_through_BLOCK;
+                "can_read_through_BLOCK/512" >:: OUnitLwt.lwt_wrapper Sector512.can_read_through_BLOCK;
+                "not 4KiB padded" >:: OUnitLwt.lwt_wrapper Sector512.check_not_padded;
+                "can_read_through_BLOCK/4096" >:: OUnitLwt.lwt_wrapper Sector4096.can_read_through_BLOCK;
                 "can write pax headers" >:: can_write_pax;
                 "can read @Longlink" >:: can_list_longlink_tar;
               ] in
   (* pwd = _build/default/lib_test *)
   Unix.chdir "../../..";
-  run_test_tt ~verbose:!verbose suite
+  run_test_tt_main suite

--- a/mirage/tar_mirage.ml
+++ b/mirage/tar_mirage.ml
@@ -209,6 +209,6 @@ module Make_KV_RO (BLOCK : Mirage_block.S) = struct
     let map = Dict (Tar.Header.make "/" 0L, map) in
     Lwt.return ({ b; map; info })
 
-  let disconnect _ = Lwt.return ()
+  let disconnect _ = Lwt.return_unit
 
 end

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -27,6 +27,7 @@ depends: [
   "io-page-unix" {with-test}
   "mirage-block-unix" {with-test & >= "2.5.0"}
   "ounit2" {with-test}
+  "ounit2-lwt" {with-test}
   "tar-unix" {with-test & = version}
   "odoc" {with-doc}
 ]

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -7,7 +7,7 @@ streaming.  This library is functorised over external OS dependencies
 to facilitate embedding within MirageOS.
 """
 maintainer: ["dave@recoil.org"]
-authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
 license: "ISC"
 tags: ["org:xapi-project" "org:mirage"]
 homepage: "https://github.com/mirage/ocaml-tar"

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -15,7 +15,7 @@ doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.08.0"}
   "cstruct" {>= "1.9.0"}
   "io-page"
   "lwt"

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -39,8 +39,7 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files"
-    "false"
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}

--- a/tar-unix.opam
+++ b/tar-unix.opam
@@ -6,7 +6,7 @@ tar is a simple library to read and write tar files with an emphasis on
 streaming.  This library provides a Unix or Windows compatible interface.
 """
 maintainer: ["dave@recoil.org"]
-authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
 license: "ISC"
 tags: ["org:xapi-project" "org:mirage"]
 homepage: "https://github.com/mirage/ocaml-tar"

--- a/tar-unix.opam
+++ b/tar-unix.opam
@@ -31,8 +31,7 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files"
-    "false"
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}

--- a/tar.opam
+++ b/tar.opam
@@ -16,7 +16,7 @@ doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "ppx_cstruct" {build & >= "3.6.0"}
   "cstruct" {>= "6.0.0"}
   "re"

--- a/tar.opam
+++ b/tar.opam
@@ -8,7 +8,7 @@ streaming.
 This is pure OCaml code, no C bindings.
 """
 maintainer: ["dave@recoil.org"]
-authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
 license: "ISC"
 tags: ["org:xapi-project" "org:mirage"]
 homepage: "https://github.com/mirage/ocaml-tar"

--- a/tar.opam
+++ b/tar.opam
@@ -31,8 +31,7 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files"
-    "false"
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}

--- a/unix/tar_lwt_unix.ml
+++ b/unix/tar_lwt_unix.ml
@@ -136,10 +136,10 @@ module Archive = struct
   let create files ofd =
     let file filename =
       Lwt_unix.stat filename >>= fun stat ->
-      if stat.Unix.st_kind <> Unix.S_REG then begin
-        Printf.eprintf "Skipping %s: not a regular file\n" filename;
+      if stat.Unix.st_kind <> Unix.S_REG then
+        (* Skipping, not a regular file. *)
         Lwt.return_unit
-      end else begin
+      else begin
         header_of_file filename >>= fun hdr ->
 
         write_block hdr (fun ofd ->

--- a/unix/tar_lwt_unix.ml
+++ b/unix/tar_lwt_unix.ml
@@ -15,7 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Lwt
+open Lwt.Infix
 
 module Reader = struct
   type in_channel = Lwt_unix.file_descr
@@ -25,7 +25,7 @@ module Reader = struct
     let buffer_size = 32768 in
     let buffer = Cstruct.create buffer_size in
     let rec loop (n: int) =
-      if n <= 0 then return ()
+      if n <= 0 then Lwt.return ()
       else
         let amount = min n buffer_size in
         let block = Cstruct.sub buffer 0 amount in
@@ -45,7 +45,7 @@ let copy_n ifd ofd n =
   let block_size = 32768 in
   let buffer = Cstruct.create block_size in
   let rec loop remaining =
-    if remaining = 0L then return () else begin
+    if remaining = 0L then Lwt.return () else begin
       let this = Int64.(to_int (min (of_int block_size) remaining)) in
       let block = Cstruct.sub buffer 0 this in
       really_read ifd block >>= fun () ->
@@ -60,8 +60,8 @@ module HW = Tar.HeaderWriter(Lwt)(Writer)
 let get_next_header ?level ic =
   HR.read ?level ic
   >>= function
-  | Error `Eof -> return None
-  | Ok hdr -> return (Some hdr)
+  | Error `Eof -> Lwt.return None
+  | Ok hdr -> Lwt.return (Some hdr)
 
 (** Return the header needed for a particular file on disk *)
 let header_of_file ?level (file: string) : Tar.Header.t Lwt.t =
@@ -105,14 +105,14 @@ module Archive = struct
     | Some hdr ->
       f fd hdr >>= fun result ->
       Reader.skip fd (Tar.Header.compute_zero_padding_length hdr) >>= fun () ->
-      return (Some result)
+      Lwt.return (Some result)
     | None ->
-      return None
+      Lwt.return None
 
   (** List the contents of a tar *)
   let list ?level fd =
     let rec loop acc = get_next_header ?level fd >>= function
-      | None -> return (List.rev acc)
+      | None -> Lwt.return (List.rev acc)
       | Some hdr ->
         Reader.skip fd (Int64.to_int hdr.Tar.Header.file_size) >>= fun () ->
         Reader.skip fd (Tar.Header.compute_zero_padding_length hdr) >>= fun () ->
@@ -122,7 +122,7 @@ module Archive = struct
   (** Extract the contents of a tar to directory 'dest' *)
   let extract dest ifd =
     let rec loop () = get_next_header ifd >>= function
-      | None -> return ()
+      | None -> Lwt.return ()
       | Some hdr ->
         let filename = dest hdr.Tar.Header.file_name in
         Lwt_unix.openfile filename [Unix.O_WRONLY] 0644 >>= fun ofd ->
@@ -138,7 +138,7 @@ module Archive = struct
       Lwt_unix.stat filename >>= fun stat ->
       if stat.Unix.st_kind <> Unix.S_REG then begin
         Printf.eprintf "Skipping %s: not a regular file\n" filename;
-        return ()
+        Lwt.return ()
       end else begin
         header_of_file filename >>= fun hdr ->
 

--- a/unix/tar_lwt_unix.ml
+++ b/unix/tar_lwt_unix.ml
@@ -25,7 +25,7 @@ module Reader = struct
     let buffer_size = 32768 in
     let buffer = Cstruct.create buffer_size in
     let rec loop (n: int) =
-      if n <= 0 then Lwt.return ()
+      if n <= 0 then Lwt.return_unit
       else
         let amount = min n buffer_size in
         let block = Cstruct.sub buffer 0 amount in
@@ -45,7 +45,7 @@ let copy_n ifd ofd n =
   let block_size = 32768 in
   let buffer = Cstruct.create block_size in
   let rec loop remaining =
-    if remaining = 0L then Lwt.return () else begin
+    if remaining = 0L then Lwt.return_unit else begin
       let this = Int64.(to_int (min (of_int block_size) remaining)) in
       let block = Cstruct.sub buffer 0 this in
       really_read ifd block >>= fun () ->
@@ -122,7 +122,7 @@ module Archive = struct
   (** Extract the contents of a tar to directory 'dest' *)
   let extract dest ifd =
     let rec loop () = get_next_header ifd >>= function
-      | None -> Lwt.return ()
+      | None -> Lwt.return_unit
       | Some hdr ->
         let filename = dest hdr.Tar.Header.file_name in
         Lwt_unix.openfile filename [Unix.O_WRONLY] 0644 >>= fun ofd ->
@@ -138,7 +138,7 @@ module Archive = struct
       Lwt_unix.stat filename >>= fun stat ->
       if stat.Unix.st_kind <> Unix.S_REG then begin
         Printf.eprintf "Skipping %s: not a regular file\n" filename;
-        Lwt.return ()
+        Lwt.return_unit
       end else begin
         header_of_file filename >>= fun hdr ->
 

--- a/unix/tar_lwt_unix.ml
+++ b/unix/tar_lwt_unix.ml
@@ -125,7 +125,7 @@ module Archive = struct
       | None -> Lwt.return_unit
       | Some hdr ->
         let filename = dest hdr.Tar.Header.file_name in
-        Lwt_unix.openfile filename [Unix.O_WRONLY] 0644 >>= fun ofd ->
+        Lwt_unix.openfile filename [Unix.O_WRONLY] 0 >>= fun ofd ->
         copy_n ifd ofd hdr.Tar.Header.file_size >>= fun () ->
         Reader.skip ifd (Tar.Header.compute_zero_padding_length hdr) >>= fun () ->
         loop () in
@@ -143,7 +143,7 @@ module Archive = struct
         header_of_file filename >>= fun hdr ->
 
         write_block hdr (fun ofd ->
-            Lwt_unix.openfile filename [Unix.O_RDONLY] 0644 >>= fun ifd ->
+            Lwt_unix.openfile filename [Unix.O_RDONLY] 0 >>= fun ifd ->
             copy_n ifd ofd hdr.Tar.Header.file_size
           ) ofd
       end in

--- a/unix/tar_lwt_unix.mli
+++ b/unix/tar_lwt_unix.mli
@@ -50,6 +50,12 @@ module Archive : sig
      top-level of the archive. *)
   val extract : (string -> string) -> Lwt_unix.file_descr -> unit Lwt.t
 
+  (** [transform f in_fd out_fd] applies [f] to the header of each
+     file in the tar inputted in [in_fd], and writes the resulting
+     headers to [out_fd] preserving the content and structure of the
+     archive. *)
+  val transform : ?level:Tar.Header.compatibility -> (Tar.Header.t -> Tar.Header.t) -> Lwt_unix.file_descr -> Lwt_unix.file_descr -> unit Lwt.t
+
   (** Create a tar on file descriptor fd from a list of filenames. It
      only supports regular files. *)
   val create : string list -> Lwt_unix.file_descr -> unit Lwt.t

--- a/unix/tar_lwt_unix.mli
+++ b/unix/tar_lwt_unix.mli
@@ -45,9 +45,12 @@ module Archive : sig
   val list : ?level:Tar.Header.compatibility -> Lwt_unix.file_descr -> Tar.Header.t list Lwt.t
 
   (** [extract dest] extract the contents of a tar.
-      Apply [dest] on each source filename to change the destination filename. *)
+     Apply [dest] on each source filename to change the destination
+     filename. It only supports extracting regular files from the
+     top-level of the archive. *)
   val extract : (string -> string) -> Lwt_unix.file_descr -> unit Lwt.t
 
-  (** Create a tar on file descriptor fd from a list of filenames. *)
+  (** Create a tar on file descriptor fd from a list of filenames. It
+     only supports regular files. *)
   val create : string list -> Lwt_unix.file_descr -> unit Lwt.t
 end

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -47,20 +47,6 @@ module Driver = struct
   let close_out = Unix.close
 end
 
-module List = struct
-  include List
-
-  let filter_map f l =
-    let rec g a = function
-        [] -> List.rev a
-      | x::l ->
-        match f x with
-          None -> g a l
-        | Some x -> g (x::a) l
-    in
-    g [] l
-end
-
 module T = Tar.Make(Driver)
 
 let really_write = T.really_write

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -83,7 +83,7 @@ module Archive = struct
   let extract dest ifd =
     let dest hdr =
       let filename = dest hdr.Tar.Header.file_name in
-      Unix.openfile filename [Unix.O_WRONLY] 0644
+      Unix.openfile filename [Unix.O_WRONLY] 0
     in
     extract_gen dest ifd
 
@@ -100,7 +100,7 @@ module Archive = struct
         else
           let hdr = header_of_file filename in
           Some (hdr, (fun ofd ->
-              let ifd = Unix.openfile filename [Unix.O_RDONLY] 0644 in
+              let ifd = Unix.openfile filename [Unix.O_RDONLY] 0 in
               copy_n ifd ofd hdr.Tar.Header.file_size))
       in
       List.filter_map f files

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -94,10 +94,9 @@ module Archive = struct
       let f filename =
         let stat = Unix.stat filename in
         if stat.Unix.st_kind <> Unix.S_REG
-        then begin
-          Printf.eprintf "Skipping %s: not a regular file\n" filename;
+        then
+          (* Skipping, not a regular file. *)
           None
-        end
         else
           let hdr = header_of_file filename in
           Some (hdr, (fun ofd ->

--- a/unix/tar_unix.mli
+++ b/unix/tar_unix.mli
@@ -54,10 +54,13 @@ module Archive : sig
   val list : ?level:Tar.Header.compatibility -> Unix.file_descr -> Tar.Header.t list
 
   (** [extract dest] extract the contents of a tar.
-      Apply [dest] on each source filename to change the destination filename. *)
+     Apply [dest] on each source filename to change the destination
+     filename. It only supports extracting regular files from the
+     top-level of the archive. *)
   val extract : (string -> string) -> Unix.file_descr -> unit
 
-  (** Create a tar on file descriptor fd from the filename list 'files'. *)
+  (** Create a tar on file descriptor fd from the filename list
+     'files'. It only supports regular files. *)
   val create : string list -> Unix.file_descr -> unit
 
   (** [copy_n ifd odf n] copies exactly [n] bytes from [ifd] to [ofd]. *)

--- a/unix/tar_unix.mli
+++ b/unix/tar_unix.mli
@@ -59,6 +59,12 @@ module Archive : sig
      top-level of the archive. *)
   val extract : (string -> string) -> Unix.file_descr -> unit
 
+  (** [transform f in_fd out_fd] applies [f] to the header of each
+      file in the tar inputted in [in_fd], and writes the resulting
+      headers to [out_fd] preserving the content and structure of the
+      archive. *)
+  val transform : ?level:Tar.Header.compatibility -> (Tar.Header.t -> Tar.Header.t) -> Unix.file_descr -> Unix.file_descr -> unit
+
   (** Create a tar on file descriptor fd from the filename list
      'files'. It only supports regular files. *)
   val create : string list -> Unix.file_descr -> unit


### PR DESCRIPTION
This PR updates the testing code to use the OUnit2 API, and the library to use OCaml 4.08 minimum, thus removing some back-ported functions. It also includes some cleanups and doc clarifications.