### PR TITLE
Document Header.make, file_mode defaults to 0o400

### DIFF
--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -284,7 +284,7 @@ module Header = struct
            }
 
   (** Helper function to make a simple header *)
-  let make ?(file_mode=0) ?(user_id=0) ?(group_id=0) ?(mod_time=0L) ?(link_indicator=Link.Normal) ?(link_name="") ?(uname="") ?(gname="") ?(devmajor=0) ?(devminor=0) file_name file_size =
+  let make ?(file_mode=0o400) ?(user_id=0) ?(group_id=0) ?(mod_time=0L) ?(link_indicator=Link.Normal) ?(link_name="") ?(uname="") ?(gname="") ?(devmajor=0) ?(devminor=0) file_name file_size =
     (* If some fields are too big, we must use a pax header *)
     let need_pax_header =
        file_size   > 0o077777777777L

--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -87,6 +87,12 @@ module Header : sig
   }
 
   (** Helper function to make a simple header. *)
+
+  (** [make file_name file_size] creates a simple header.
+      [file_mode] defaults to [0o400], [user_id], [group_id] default to [0],
+      [mod_time] defaults to [0L] (epoch), [link_indicator] defaults to [Normal],
+      [link_name], [uname] and [gname] default to [""], and [devmajor] and
+      [devminor] default to [0].*)
   val make : ?file_mode:int -> ?user_id:int -> ?group_id:int -> ?mod_time:int64 -> ?link_indicator:Link.t -> ?link_name:string -> ?uname:string -> ?gname:string -> ?devmajor:int -> ?devminor:int -> string -> int64 -> t
 
   (** Length of a header block. *)


### PR DESCRIPTION
`Tar.Header.make` takes a number of optional arguments. This PR adds brief documentation of what their default values are.

It also changes the default of `file_mode` from `0o000` to `0o400` (i.e. read-only by owner). While `0o000` is a very safe default and a good motivator for setting another value I think `0o400` is a safe and more useful default. Alternatively, I think it makes sense to make `file_mode` into a required labeled argument. 