### PR TITLE
Close files

### DIFF
--- a/unix/tar_lwt_unix.ml
+++ b/unix/tar_lwt_unix.ml
@@ -128,7 +128,7 @@ module Archive = struct
       | None -> Lwt.return_unit
       | Some hdr ->
         let filename = dest hdr.Tar.Header.file_name in
-        with_file filename [Unix.O_WRONLY] 0 @@ fun ofd ->
+        with_file filename [Unix.O_WRONLY; O_CLOEXEC] 0 @@ fun ofd ->
         copy_n ifd ofd hdr.Tar.Header.file_size >>= fun () ->
         Reader.skip ifd (Tar.Header.compute_zero_padding_length hdr) >>= fun () ->
         loop () in
@@ -158,7 +158,7 @@ module Archive = struct
         header_of_file filename >>= fun hdr ->
 
         write_block hdr (fun ofd ->
-            with_file filename [Unix.O_RDONLY] 0 @@ fun ifd ->
+            with_file filename [O_RDONLY; O_CLOEXEC] 0 @@ fun ifd ->
             copy_n ifd ofd hdr.Tar.Header.file_size
           ) ofd
       end in

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -87,7 +87,7 @@ module Archive = struct
   let extract dest ifd =
     let dest hdr =
       let filename = dest hdr.Tar.Header.file_name in
-      Unix.openfile filename [Unix.O_WRONLY] 0
+      Unix.openfile filename [O_WRONLY; O_CLOEXEC] 0
     in
     extract_gen dest ifd
 
@@ -117,7 +117,7 @@ module Archive = struct
         else
           let hdr = header_of_file filename in
           Some (hdr, (fun ofd ->
-              with_file filename [Unix.O_RDONLY] 0 @@ fun ifd ->
+              with_file filename [O_RDONLY; O_CLOEXEC] 0 @@ fun ifd ->
               copy_n ifd ofd hdr.Tar.Header.file_size))
       in
       List.filter_map f files


### PR DESCRIPTION
Avoid files descriptors leaking by closing them and setting `O_CLOEXEC`.