### PR TITLE
tar-mirage: remove io-page usage, make it compatible with solo5

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -66,7 +66,6 @@
  (depends
   (ocaml (>= 4.08.0))
   (cstruct (>= 1.9.0))
-  (io-page (>= 2.4.0))
   lwt
   (mirage-block (>= 2.0.0))
   (mirage-kv (>= 3.0.0))

--- a/dune-project
+++ b/dune-project
@@ -66,7 +66,7 @@
   (cstruct (>= 1.9.0))
   lwt
   (mirage-block (>= 2.0.0))
-  (mirage-kv (>= 3.0.0))
+  (mirage-kv (and (>= 3.0.0) (< 5.0.0)))
   ptime
   (tar (= :version))
   (mirage-block-unix (and :with-test (>= 2.5.0)))

--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,6 @@
   (ocaml (>= 4.08.0))
   (ppx_cstruct (and :build (>= 3.6.0)))
   (cstruct (>= 6.0.0))
-  (re (>= 1.7.2))
   (decompress (>= 1.5.1))
  )
 )
@@ -49,7 +48,6 @@
   (cstruct (>= 6.0.0))
   cstruct-lwt
   lwt
-  (re (>= 1.7.2))
   (tar (= :version))
  )
 )
@@ -70,7 +68,6 @@
   (mirage-block (>= 2.0.0))
   (mirage-kv (>= 3.0.0))
   ptime
-  (re (>= 1.7.2))
   (tar (= :version))
   (mirage-block-unix (and :with-test (>= 2.5.0)))
   (ounit2 :with-test)

--- a/lib/dune
+++ b/lib/dune
@@ -4,7 +4,6 @@
  (public_name tar)
  (wrapped false)
  (libraries cstruct camlp-streams)
- (flags :standard -safe-string)
  (preprocess
   (pps ppx_cstruct)))
 
@@ -13,5 +12,4 @@
  (modules tar_gz)
  (public_name tar.gz)
  (wrapped false)
- (libraries tar decompress.gz decompress.de)
- (flags :standard -safe-string))
+ (libraries tar decompress.gz decompress.de))

--- a/lib/dune
+++ b/lib/dune
@@ -3,7 +3,7 @@
  (modules tar tar_cstruct)
  (public_name tar)
  (wrapped false)
- (libraries cstruct re.str camlp-streams)
+ (libraries cstruct camlp-streams)
  (flags :standard -safe-string)
  (preprocess
   (pps ppx_cstruct)))

--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -51,7 +51,7 @@ module Header = struct
       let first_0 = String.index x '\000' in
       String.sub x 0 first_0
     with
-      Not_found -> ""
+      Not_found -> x (* TODO should error *)
 
   (** Unmarshal a pax Extended Header File time
       It can contain a <period> ( '.' ) for sub-second granularity, that we ignore.

--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -27,7 +27,7 @@ module Header = struct
       let byte = Printf.sprintf "%02x" (int_of_char x.[i]) in
       Bytes.blit_string byte 0 result (i * 3) 2
     done;
-    Bytes.to_string result
+    Bytes.unsafe_to_string result
 
   let trim regexp x = match Re.Str.split regexp x with
     | [] -> ""
@@ -330,14 +330,14 @@ module Header = struct
     if String.length x >= n then x
     else let buffer = Bytes.make n c in
       Bytes.blit_string x 0 buffer (n - (String.length x)) (String.length x);
-      Bytes.to_string buffer
+      Bytes.unsafe_to_string buffer
 
   (** Return a string containing 'x' padded out to 'n' bytes by adding 'c' to the RHS *)
   let pad_right (x: string) (n: int) (c: char) =
     if String.length x >= n then x
     else let buffer = Bytes.make n c in
       Bytes.blit_string x 0 buffer 0 (String.length x);
-      Bytes.to_string buffer
+      Bytes.unsafe_to_string buffer
 
   (** Pretty-print the header record *)
   let to_detailed_string (x: t) =

--- a/mirage/dune
+++ b/mirage/dune
@@ -1,5 +1,5 @@
 (library
  (name tar_mirage)
  (public_name tar-mirage)
- (libraries tar io-page lwt mirage-kv mirage-block ptime)
+ (libraries tar lwt mirage-kv mirage-block ptime)
  (wrapped false))

--- a/mirage/tar_mirage.ml
+++ b/mirage/tar_mirage.ml
@@ -98,9 +98,8 @@ module Make_KV_RO (BLOCK : Mirage_block.S) = struct
     | Error e -> Lwt.return (Error e)
     | Ok (Dict _) -> Lwt.return (Error (`Value_expected key))
     | Ok (Value (hdr, start_sector)) ->
-      BLOCK.get_info t.b >>= fun info ->
       let open Int64 in
-      let sector_size = of_int info.Mirage_block.sector_size in
+      let sector_size = of_int t.info.Mirage_block.sector_size in
 
       (* Compute the unaligned data we need to read *)
       let start_bytes = mul start_sector 512L in

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -19,7 +19,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "lwt"
   "mirage-block" {>= "2.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
   "ptime"
   "tar" {= version}
   "mirage-block-unix" {with-test & >= "2.5.0"}

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -17,7 +17,6 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08.0"}
   "cstruct" {>= "1.9.0"}
-  "io-page" {>= "2.4.0"}
   "lwt"
   "mirage-block" {>= "2.0.0"}
   "mirage-kv" {>= "3.0.0"}

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -21,7 +21,6 @@ depends: [
   "mirage-block" {>= "2.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "ptime"
-  "re" {>= "1.7.2"}
   "tar" {= version}
   "mirage-block-unix" {with-test & >= "2.5.0"}
   "ounit2" {with-test}

--- a/tar-unix.opam
+++ b/tar-unix.opam
@@ -18,7 +18,6 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "cstruct-lwt"
   "lwt"
-  "re" {>= "1.7.2"}
   "tar" {= version}
   "odoc" {with-doc}
 ]

--- a/tar.opam
+++ b/tar.opam
@@ -20,7 +20,6 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "ppx_cstruct" {build & >= "3.6.0"}
   "cstruct" {>= "6.0.0"}
-  "re" {>= "1.7.2"}
   "decompress" {>= "1.5.1"}
   "odoc" {with-doc}
 ]

--- a/unix/dune
+++ b/unix/dune
@@ -2,5 +2,4 @@
  (name tar_unix)
  (public_name tar-unix)
  (libraries tar lwt cstruct-lwt)
- (flags :standard -safe-string)
  (wrapped false))


### PR DESCRIPTION
in solo5, a block.read reads block-wise - passing a smaller or larger buffer results
in an error

tar-mirage: also avoid capturing the root "./" directory (where filename = ""
after trimming) -- later "/" is added, and there's not much value in it (apart
from assertion failures)