### PR TITLE
Depend on camlp-streams

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,7 @@
   (ppx_cstruct (and :build (>= 3.6.0)))
   (cstruct (>= 6.0.0))
   re
+  camlp-streams
  )
 )
 

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name tar)
  (public_name tar)
  (wrapped false)
- (libraries cstruct re.str)
+ (libraries cstruct re.str camlp-streams)
  (flags :standard -safe-string)
  (preprocess
   (pps ppx_cstruct)))

--- a/tar.opam
+++ b/tar.opam
@@ -20,6 +20,7 @@ depends: [
   "ppx_cstruct" {build & >= "3.6.0"}
   "cstruct" {>= "6.0.0"}
   "re"
+  "camlp-streams"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Stdlib.Streams is deprecated since OCaml 4.14.0 and packaged separately.

Fixes #91.