### PR TITLE
Add failing tests

### DIFF
--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,5 +1,5 @@
 (tests
- (names parse_test)
+ (names parse_test write_test)
  (package tar-mirage)
  (libraries
   mirage-block-unix

--- a/lib_test/write_test.ml
+++ b/lib_test/write_test.ml
@@ -1,0 +1,112 @@
+open OUnit2
+open Lwt.Infix
+
+module B(Size : sig val block_size : int end) = struct
+  include Block
+  include Size
+
+  let convert_path os path =
+    let ch = Unix.open_process_in (Printf.sprintf "cygpath -%c -- %s" (match os with `Mixed -> 'm' | `Unix -> 'u' | `Windows -> 'w') path) in
+    let line = input_line ch in
+    close_in ch;
+    line
+
+  let connect name =
+    let name = if Sys.win32 then convert_path `Windows name else name in
+    connect ~prefered_sector_size:(Some block_size) name
+end
+
+module Block512 = B(struct let block_size = 512 end)
+
+module Block4096 = B(struct let block_size = 4096 end)
+
+module type BLOCK = sig
+  include module type of Block
+  val connect: string -> t Lwt.t
+  val block_size : int
+end
+
+module Test(B : BLOCK) = struct
+  module KV_RW = Tar_mirage.Make_KV_RW(Pclock)(B)
+
+  let kv_rw_write_error =
+    Lwt.wrap1
+      (Result.iter_error (Fmt.kstr failwith "%a" KV_RW.pp_write_error))
+
+  let str n =
+    Bytes.unsafe_to_string (Bytes.create n)
+
+  let connect_block test_ctxt =
+    let filename, ch = bracket_tmpfile ~prefix:"tar-write-test" ~suffix:".tar" test_ctxt in
+    close_out ch;
+    B.connect filename
+
+  let resize b size =
+    B.resize b size >|= fun x ->
+    Result.iter_error (fun e ->
+        Fmt.kstr failwith "%a" B.pp_write_error e)
+      x
+
+  let write_empty_file test_ctxt =
+    connect_block test_ctxt >>= fun b ->
+    resize b 10240L >>= fun () ->
+    KV_RW.connect b >>= fun t ->
+    KV_RW.set t (Mirage_kv.Key.v "barf") "" >>=
+    kv_rw_write_error >>= fun () ->
+    Lwt.return_unit
+
+  let write_block_size_file test_ctxt =
+    connect_block test_ctxt >>= fun b ->
+    resize b 10240L >>= fun () ->
+    KV_RW.connect b >>= fun t ->
+    KV_RW.set t (Mirage_kv.Key.v "barf") (str B.block_size) >>=
+    kv_rw_write_error >>= fun () ->
+    Lwt.return_unit
+
+  let write_block_size test_ctxt =
+    connect_block test_ctxt >>= fun b ->
+    resize b 10240L >>= fun () ->
+    KV_RW.connect b >>= fun t ->
+    KV_RW.set t (Mirage_kv.Key.v "barf") (str (B.block_size - 512)) >>=
+    kv_rw_write_error >>= fun () ->
+    Lwt.return_unit
+
+  let write_two_block_size ctx =
+    connect_block ctx >>= fun b ->
+    resize b 10240L >>= fun () ->
+    KV_RW.connect b >>= fun t ->
+    KV_RW.set t (Mirage_kv.Key.v "barf") (str (2 * B.block_size - 512)) >>=
+    kv_rw_write_error >>= fun () ->
+    Lwt.return_unit
+
+  let write_two_files ctx =
+    connect_block ctx >>= fun b ->
+    resize b 10240L >>= fun () ->
+    KV_RW.connect b >>= fun t ->
+    KV_RW.set t (Mirage_kv.Key.v "first") (str (B.block_size - 512)) >>=
+    kv_rw_write_error >>= fun () ->
+    KV_RW.set t (Mirage_kv.Key.v "second") (str (2 * B.block_size - 512)) >>=
+    kv_rw_write_error >>= fun () ->
+    Lwt.return_unit
+end
+
+module Test512 = Test(Block512)
+module Test4096 = Test(Block4096)
+
+let () =
+  let suite =
+    "tar-write" >:::
+    [
+      "write empty b512" >:: OUnitLwt.lwt_wrapper Test512.write_empty_file;
+      "write empty b4096" >:: OUnitLwt.lwt_wrapper Test4096.write_empty_file;
+      "write block size 512" >:: OUnitLwt.lwt_wrapper Test512.write_block_size_file;
+      "write block size 4096" >:: OUnitLwt.lwt_wrapper Test4096.write_block_size_file;
+      "write block size 512" >:: OUnitLwt.lwt_wrapper Test512.write_block_size;
+      "write block size 4096" >:: OUnitLwt.lwt_wrapper Test4096.write_block_size;
+      "write two blocks 512" >:: OUnitLwt.lwt_wrapper Test512.write_two_block_size;
+      "write two blocks 4096" >:: OUnitLwt.lwt_wrapper Test4096.write_two_block_size;
+      "write two files 512" >:: OUnitLwt.lwt_wrapper Test512.write_two_files;
+      "write two files 4096" >:: OUnitLwt.lwt_wrapper Test4096.write_two_files;
+    ]
+  in
+  run_test_tt_main suite

--- a/mirage/tar_mirage.ml
+++ b/mirage/tar_mirage.ml
@@ -134,6 +134,7 @@ module Make_KV_RO (BLOCK : Mirage_block.S) = struct
         let end_sector = div end_bytes sector_size in
         let n_sectors = succ (sub end_sector start_sector) in
         let buf = Cstruct.create (to_int (mul n_sectors sector_size)) in
+        (* XXX: this is to work around limitations in some block implementations *)
         let tmps =
           List.init (to_int n_sectors)
             (fun sec -> Cstruct.sub buf (sec * to_int sector_size) (to_int sector_size))
@@ -388,6 +389,7 @@ module Make_KV_RW (CLOCK : Mirage_clock.PCLOCK) (BLOCK : Mirage_block.S) = struc
            - then the header AND the first tar block
         *)
         let remaining_sectors =
+          (* XXX: this is to work around limitations in some block implementations *)
           List.init (Cstruct.length remaining_sectors / to_int sector_size)
             (fun sector ->
                Cstruct.sub remaining_sectors

--- a/mirage/tar_mirage.ml
+++ b/mirage/tar_mirage.ml
@@ -277,6 +277,7 @@ module Make_KV_RW (CLOCK : Mirage_clock.PCLOCK) (BLOCK : Mirage_block.S) = struc
     in
     Tar.Header.make ~mod_time (Mirage_kv.Key.to_string key) (Int64.of_int len)
 
+  (* [space_needed header] is the number of bytes necessary for the data part including padding *)
   let space_needed header =
     let data_size = header.Tar.Header.file_size in
     let padding_size = Tar.Header.compute_zero_padding_length header in
@@ -349,60 +350,56 @@ module Make_KV_RW (CLOCK : Mirage_clock.PCLOCK) (BLOCK : Mirage_block.S) = struc
         let open Int64 in
         let sector_size = of_int t.info.Mirage_block.sector_size in
 
-        let start_bytes = sub t.end_of_archive (of_int Tar.Header.length) in
-        let header_start_bytes = sub start_bytes (of_int Tar.Header.length) in
+        let data_start_bytes = sub t.end_of_archive (of_int Tar.Header.length) in
+        let header_start_bytes = sub data_start_bytes (of_int Tar.Header.length) in
         let sentinel = mul 2L (of_int Tar.Header.length) in
-        let end_bytes = add start_bytes (add space_needed sentinel) in
-        (* Compute the starting sector and ending sector (rounding down then up) *)
-        let start_sector, start_sector_offset = div start_bytes sector_size, rem start_bytes sector_size in
+        let end_bytes = add data_start_bytes (add space_needed sentinel) in
+        (* Compute the starting sector and ending sector *)
+        let data_start_sector, data_start_sector_offset =
+          div data_start_bytes sector_size,
+          rem data_start_bytes sector_size
+        in
         let end_sector = div end_bytes sector_size in
         let end_sector_offset = rem end_bytes sector_size in
-        let data_sectors = sub end_sector start_sector in
         let pad = Tar.Header.compute_zero_padding_length hdr in
         let data = Cstruct.append data (Cstruct.create (pad + to_int sentinel)) in
-        let first_sector, rest =
+
+        let first_sector, remaining_sectors =
           let s =
             Stdlib.min
               (Cstruct.length data)
-              (to_int (sub sector_size start_sector_offset))
+              (to_int (sub sector_size data_start_sector_offset))
           in
           Cstruct.split data s
         in
-        let remaining_sectors, last_sector =
-          let full_sectors =
-            (* the first sector is special (written last, may be partial) *)
-            let remaining_sectors = to_int (pred data_sectors) in
-            let last_is_full = end_sector_offset = 0L in
-            if last_is_full then remaining_sectors else remaining_sectors - 1
-          in
-          if full_sectors <= 0 then
-            [], rest
-          else
-            List.init full_sectors
-              (fun sec ->
-                 Cstruct.sub rest (sec * to_int sector_size)
-                   (to_int sector_size)),
-            Cstruct.shift rest (full_sectors * to_int sector_size)
-        in
+        (* Blit last sector if necessary *)
+        begin
+          if end_sector_offset = 0L then
+            Lwt.return_ok remaining_sectors
+          else begin
+            let buf = Cstruct.create (to_int sector_size) in
+            Lwt_result.map_error (fun e -> `Block e)
+              (BLOCK.read t.b end_sector [buf]) >>>= fun () ->
+            Lwt.return_ok
+              (Cstruct.append remaining_sectors
+                 (snd (Cstruct.split buf (to_int end_sector_offset))))
+          end
+        end >>>= fun remaining_sectors ->
         (* to write robustly as we can:
-           - we first write the last block, then
-           - we write tar blocks 2..end-1,
-           - finally the header AND the first tar block
+           - we write tar blocks 2..end,
+           - then the header AND the first tar block
         *)
-        let buf = Cstruct.create (to_int sector_size) in
-        (if Cstruct.length last_sector > 0 then
-           Lwt_result.map_error (function e -> `Block e)
-             (BLOCK.read t.b end_sector [ buf ]) >>>= fun () ->
-           Cstruct.blit last_sector 0 buf
-             (to_int end_sector_offset - Cstruct.length last_sector)
-             (Cstruct.length last_sector);
-           Lwt_result.map_error (fun e -> `Block_write e)
-             (BLOCK.write t.b end_sector [ buf ])
-         else
-           Lwt.return (Ok ())) >>>= fun () ->
+
         (* write full blocks 2 .. end *)
+        let remaining_sectors =
+          List.init (Cstruct.length remaining_sectors / to_int sector_size)
+            (fun sector ->
+               Cstruct.sub remaining_sectors
+                 (sector * to_int sector_size)
+                 (to_int sector_size))
+        in
         Lwt_result.map_error (fun e -> `Block_write e)
-          (BLOCK.write t.b (succ start_sector) remaining_sectors) >>>= fun () ->
+          (BLOCK.write t.b (succ data_start_sector) remaining_sectors) >>>= fun () ->
         (* finally write header and first block *)
         let hw = Writer.{ b = t.b ; offset = header_start_bytes ; info = t.info } in
         Lwt.catch
@@ -411,12 +408,13 @@ module Make_KV_RW (CLOCK : Mirage_clock.PCLOCK) (BLOCK : Mirage_block.S) = struc
             | Writer.Read e -> Lwt.return (Error (`Block e))
             | Writer.Write e -> Lwt.return (Error (`Block_write e))
             | exn -> raise exn) >>>= fun () ->
+        let buf = Cstruct.create (to_int sector_size) in
         Lwt_result.map_error (function e -> `Block e)
-          (BLOCK.read t.b start_sector [ buf ]) >>>= fun () ->
-        Cstruct.blit first_sector 0 buf (to_int start_sector_offset)
+          (BLOCK.read t.b data_start_sector [ buf ]) >>>= fun () ->
+        Cstruct.blit first_sector 0 buf (to_int data_start_sector_offset)
           (Cstruct.length first_sector);
         Lwt_result.map_error (fun e -> `Block_write e)
-          (BLOCK.write t.b start_sector [ buf ]) >>>= fun () ->
+          (BLOCK.write t.b data_start_sector [ buf ]) >>>= fun () ->
         let tar_offset = Int64.div (sub t.end_of_archive 512L) 512L in
         t.end_of_archive <- end_bytes;
         t.map <- update_insert t.map key hdr tar_offset;


### PR DESCRIPTION
There's a corner case if sector size is greater than 512 where writes will fail with `Invalid_argument` from `Cstruct.blit`.