### PR TITLE
Document why we use `Ustar` level in tar-mirage

### DIFF
--- a/mirage/tar_mirage.ml
+++ b/mirage/tar_mirage.ml
@@ -400,6 +400,9 @@ module Make_KV_RW (CLOCK : Mirage_clock.PCLOCK) (BLOCK : Mirage_block.S) = struc
           (BLOCK.write t.b (succ data_start_sector) remaining_sectors) >>>= fun () ->
         (* finally write header and first block *)
         let hw = Writer.{ b = t.b ; offset = header_start_bytes ; info = t.info } in
+        (* it is important we write at level [Ustar] at most as we assume the
+           header(s) taking up exactly 512 bytes. With [GNU] level extra blocks
+           may be used for long names. *)
         Lwt.catch
           (fun () -> HW.write ~level:Tar.Header.Ustar hdr hw >|= fun () -> Ok ())
           (function


### PR DESCRIPTION
If we used `GNU` level we cannot assume the header(s) for a file take up exactly one block as `GNU` has support for long names. At the moment there's no mechanism to compute how much a `Tar.Header.t` will take up once written given a certain `level`.