### PR TITLE
Brushup

### DIFF
--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -238,14 +238,14 @@ module Header = struct
           match find remaining ' ' with
           | None -> failwith "Failed to decode pax extended header record"
           | Some i ->
-            let length = int_of_string @@ Cstruct.to_string ~off:0 ~len:i remaining in
+            let length = int_of_string @@ Cstruct.copy remaining 0 i in
             let record = Cstruct.sub remaining 0 length in
             let remaining = Cstruct.shift remaining length in
             begin match find record '=' with
             | None -> failwith "Failed to decode pax extended header record"
             | Some j ->
-              let keyword = Cstruct.to_string ~off:(i + 1) ~len:(j - i - 1) record in
-              let v = Cstruct.to_string ~off:(j + 1) ~len:(length - j - 2) record in
+              let keyword = Cstruct.copy record (i + 1) (j - i - 1) in
+              let v = Cstruct.copy record (j + 1) (length - j - 2) in
               (keyword, v) :: (loop remaining)
             end
         end in

--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -115,7 +115,8 @@ module Header : sig
 
   (** Unmarshal a header block, returning [None] if it's all zeroes.
       This header block may be preceded by an [?extended] block which
-      will override some fields. *)
+      will override some fields.
+      @raise Invalid_argument if the is not exactly [length] long *)
   val unmarshal : ?level:compatibility -> ?extended:Extended.t -> Cstruct.t -> t option
 
   (** Marshal a header block, computing and inserting the checksum. *)

--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -46,6 +46,7 @@ module Header : sig
       | GlobalExtendedHeader (** a PaxExtension global header *)
       | PerFileExtendedHeader (** a PaxExtension per-file header *)
       | LongLink (** a LongLink i.e. a very long filename *)
+      | LongName (** a LongName i.e. a very long filename *)
     val to_string: t -> string
   end
 


### PR DESCRIPTION
This is a bit of a code dump from a review I did before Christmas. Mostly it's refactorings and updates to newer upstream APIs. Notable changes is:

- Document exceptions and behavior
- Fix ustar version serialization - the version was serialized as `0\000` instead of `00`. Unmarshalling is more strict, but I am unsure if this is desirable.
- Fix GNU LongName/LongLink (need a revisit by me)

This is work-in-progress. The commit history is a mess, and likely I will cherry-pick the changes I like or do a squash merge in the end.