### PR TITLE
Remove Windows from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
         ocaml-compiler:
           - 4.12.x
 


### PR DESCRIPTION
The opam repository used is very outdated and consistently results in failures :( Removing it is not ideal, but the noise from the CI is quite annoying.