### PR TITLE
GitHub Actions: Windows only, updated

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,24 +13,27 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
-          - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - 4.12.x
+          - 4.14.x
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-repositories: |
+            opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+            default: https://github.com/ocaml/opam-repository.git
 
-      - run: opam install . --deps-only --with-test
+      - run: |
+          opam depext conf-pkg-config
+          opam install . --deps-only --with-test
 
       - run: opam exec -- dune build
 


### PR DESCRIPTION
ocaml-ci already tests ubuntu and macOS, so we can remove them.
Updates the opam-repo with the sunset version and the default opam-repository as a fallback, to alleviate concerns from #110.
Closes #110.
(Windows CI is still useful to me!)