### PR TITLE
Test parsing of various tar formats (with pax Global Extended Headers)

### DIFF
--- a/test/tarball.t
+++ b/test/tarball.t
@@ -1,7 +1,46 @@
-Tests of the tar binary
+Tests of the otar binary
   $ mkdir archive
   $ echo "Hello World" > archive/foo
   $ otar archive/ v.tar.gz
   $ otar list v.tar.gz
+  archive/ (0 byte)
+  archive/foo (12.00 B)
+
+Tests decoding of various tar formats
+  $ if tar --version | grep -q GNU; then
+  >   tar -cz --format=gnu -f v-gnu.tar.gz archive/
+  >   otar list v-gnu.tar.gz
+  > else printf "archive/ (0 byte)\narchive/foo (12.00 B)\n"; fi
+  archive/ (0 byte)
+  archive/foo (12.00 B)
+  $ if tar --version | grep -q GNU; then
+  >   tar -cz --format=oldgnu -f v-oldgnu.tar.gz archive/
+  >   otar list v-oldgnu.tar.gz
+  > else printf "archive/ (0 byte)\narchive/foo (12.00 B)\n"; fi
+  archive/ (0 byte)
+  archive/foo (12.00 B)
+  $ tar -cz --format=pax -f v-pax.tar.gz archive/
+  $ otar list v-pax.tar.gz
+  archive/ (0 byte)
+  archive/foo (12.00 B)
+  $ tar -cz --format=posix -f v-posix.tar.gz archive/
+  $ otar list v-posix.tar.gz
+  archive/ (0 byte)
+  archive/foo (12.00 B)
+  $ tar -cz --format=ustar -f v-ustar.tar.gz archive/
+  $ otar list v-ustar.tar.gz
+  archive/ (0 byte)
+  archive/foo (12.00 B)
+  $ tar -cz --format=v7 -f v-v7.tar.gz archive/
+  $ otar list v-v7.tar.gz
+  archive/ (0 byte)
+  archive/foo (12.00 B)
+
+Test decoding of git archive
+  $ git init -q archive && cd archive
+  $ git config user.email 'author@example.com' && git config user.name 'A U Thor'
+  $ git add . && git commit -q -m "Initial commit"
+  $ git archive -o ../archive.tar.gz --prefix=archive/ HEAD
+  $ cd ../ && otar list archive.tar.gz
   archive/ (0 byte)
   archive/foo (12.00 B)


### PR DESCRIPTION
Add a cram test exhibiting a parsing problem with `git archive` generated tarballs.
```
Fatal error: exception Tar.Header.Checksum_mismatch
Raised at Tar.Header.unmarshal in file "lib/tar.ml", line 378, characters 35-58
Called from Tar.HeaderReader.read.next_block.(fun) in file "lib/tar.ml", line 536, characters 13-45
Called from Tar.HeaderReader.read.get_hdr in file "lib/tar.ml", line 546, characters 6-13
Called from Tar.HeaderReader.read in file "lib/tar.ml", line 606, characters 4-14
Called from Tar_gz.Make.get_next_header in file "lib/tar_gz.ml", line 127, characters 4-36
Called from Dune__exe__Otar.list.go in file "bin/otar.ml", line 107, characters 24-49
Called from Dune__exe__Otar in file "bin/otar.ml", line 124, characters 4-17
[2]
```
working on a fix (help is appreciated).

See #113.