### PR TITLE
Support for pax global extended headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## unreleased
+
+- `tar`: support pax Global Extended Headers. This adds state to tar parsing.
+  (#119, #120, @MisterDA)
+
 ## v2.4.0 (2023-03-30)
 
 - Switch to alcotest for tests (@MisterDA, review by @reynir, #121)

--- a/bin/otar.ml
+++ b/bin/otar.ml
@@ -104,7 +104,7 @@ let bytes_to_size ?(decimals = 2) ppf = function
 let list filename =
   let ic = open_in filename in
   let ic = Tar_gz.of_in_channel ~internal:(Cstruct.create 0x1000) ic in
-  let rec go global () = match Tar_gz.get_next_header ?global ic with
+  let rec go global () = match Tar_gz.get_next_header ~global ic with
     | (hdr, global) ->
       Format.printf "%s (%a)\n%!"
         hdr.Tar.Header.file_name

--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -709,6 +709,8 @@ module HeaderReader(Async: ASYNC)(Reader: READER with type 'a t = 'a Async.t) = 
         >>= fun () ->
         skip ifd (Header.compute_zero_padding_length x)
         >>= fun () ->
+        (* unmarshal merges the previous global (if any) with the
+           discovered global (if any) and returns the new global. *)
         let global = Header.Extended.unmarshal ~global extra_header_buf in
         next (Some global) ()
       | x -> return x in

--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -69,7 +69,7 @@ module Header : sig
     (** [make ()] creates an extended header. *)
     val make : ?access_time:int64 -> ?charset:string -> ?comment:string -> ?group_id:int -> ?gname:string -> ?header_charset:string -> ?link_path:string -> ?mod_time:int64 -> ?path:string -> ?file_size:int64 -> ?user_id:int -> ?uname:string -> unit -> t
 
-    (** Pretty-print the header record. *)
+    (** Pretty-print the extended header record. *)
     val to_detailed_string : t -> string
 
     (** Unmarshal a pax Extended Header block. This header block may

--- a/lib/tar_cstruct.mli
+++ b/lib/tar_cstruct.mli
@@ -23,7 +23,7 @@ val really_write : out_channel -> Cstruct.t -> unit
 (** [really_write oc buf] writes the full contents of [buf] to [oc]
     or raises {!Stdlib.End_of_file}. *)
 
-val get_next_header : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t -> in_channel ->
+val get_next_header : ?level:Tar.Header.compatibility -> global:Tar.Header.Extended.t option -> in_channel ->
                       Tar.Header.t * Tar.Header.Extended.t option
 (** [get_next_header ?level ic] returns the next header block or fails with
     [`Eof] if two consecutive zero-filled blocks are discovered. Assumes [ic]
@@ -31,7 +31,7 @@ val get_next_header : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Exte
     @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
 
 module Archive : sig
-  val with_next_file : in_channel -> ?global:Tar.Header.Extended.t ->
+  val with_next_file : in_channel -> global:Tar.Header.Extended.t option ->
                        (in_channel -> Tar.Header.Extended.t option -> Tar.Header.t -> 'a) -> 'a
   (** [with_next_file ic f] Read the next header, apply the function [f] to
       [ic] and the header.  The function should leave [ic] positioned

--- a/lib/tar_cstruct.mli
+++ b/lib/tar_cstruct.mli
@@ -23,14 +23,16 @@ val really_write : out_channel -> Cstruct.t -> unit
 (** [really_write oc buf] writes the full contents of [buf] to [oc]
     or raises {!Stdlib.End_of_file}. *)
 
-val get_next_header : ?level:Tar.Header.compatibility -> in_channel -> Tar.Header.t
+val get_next_header : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t -> in_channel ->
+                      Tar.Header.t * Tar.Header.Extended.t option
 (** [get_next_header ?level ic] returns the next header block or fails with
     [`Eof] if two consecutive zero-filled blocks are discovered. Assumes [ic]
     is positioned at the possible start of a header block.
     @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
 
 module Archive : sig
-  val with_next_file : in_channel -> (in_channel -> Tar.Header.t -> 'a) -> 'a
+  val with_next_file : in_channel -> ?global:Tar.Header.Extended.t ->
+                       (in_channel -> Tar.Header.Extended.t option -> Tar.Header.t -> 'a) -> 'a
   (** [with_next_file ic f] Read the next header, apply the function [f] to
       [ic] and the header.  The function should leave [ic] positioned
       immediately after the datablock. {!really_read} can be used for this

--- a/lib/tar_gz.ml
+++ b/lib/tar_gz.ml
@@ -123,8 +123,8 @@ module Make
     ; in_channel
     ; pos= 0 }
 
-  let get_next_header ?level ?global ic =
-    TarGzHeaderReader.read ?level ?global ic >>= function
+  let get_next_header ?level ~global ic =
+    TarGzHeaderReader.read ?level ~global ic >>= function
     | Ok hdrs -> Async.return hdrs
     | Error `Eof -> raise Tar.Header.End_of_stream
 
@@ -144,8 +144,8 @@ module Make
     let gz = Gz.Def.dst gz buffer off len in
     { Gz_writer.gz; ic_buffer; oc_buffer; out_channel; }
 
-  let write_block ?level hdr ({ Gz_writer.ic_buffer= buf; oc_buffer; out_channel; _ } as state) block =
-    TarGzHeaderWriter.write ?level hdr state >>= fun () ->
+  let write_block ?level ?global hdr ({ Gz_writer.ic_buffer= buf; oc_buffer; out_channel; _ } as state) block =
+    TarGzHeaderWriter.write ?level ?global hdr state >>= fun () ->
     (* XXX(dinosaure): we can refactor this code with [Gz_writer.really_write]
        but this loop saves and uses [ic_buffer]/[buf] to avoid extra
        allocations on the case between [string] and [Cstruct.t]. *)

--- a/lib/tar_gz.ml
+++ b/lib/tar_gz.ml
@@ -99,7 +99,7 @@ module Make
         if len < max
         then ( state.pos <- state.pos + len
              ; Async.return () )
-        else ( let res = Cstruct.shift res len in 
+        else ( let res = Cstruct.shift res len in
                until_full_or_end (Gz.Inf.flush state.gz) res )
 
     let skip
@@ -123,9 +123,9 @@ module Make
     ; in_channel
     ; pos= 0 }
 
-  let get_next_header ?level ic =
-    TarGzHeaderReader.read ?level ic >>= function
-    | Ok hdr -> Async.return hdr
+  let get_next_header ?level ?global ic =
+    TarGzHeaderReader.read ?level ?global ic >>= function
+    | Ok hdrs -> Async.return hdrs
     | Error `Eof -> raise Tar.Header.End_of_stream
 
   let really_read = Gz_reader.really_read

--- a/lib/tar_gz.mli
+++ b/lib/tar_gz.mli
@@ -34,7 +34,8 @@ module Make
       positioned at the possible start of a header block.
 
       @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
-  val get_next_header : ?level:Tar.Header.compatibility -> in_channel -> Tar.Header.t Async.t
+  val get_next_header : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t -> in_channel ->
+                        (Tar.Header.t * Tar.Header.Extended.t option) Async.t
 
   val really_read : in_channel -> Cstruct.t -> unit Async.t
   (** [really_read fd buf] fills [buf] with data from [fd] or raises

--- a/lib/tar_gz.mli
+++ b/lib/tar_gz.mli
@@ -34,8 +34,8 @@ module Make
       positioned at the possible start of a header block.
 
       @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
-  val get_next_header : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t -> in_channel ->
-                        (Tar.Header.t * Tar.Header.Extended.t option) Async.t
+  val get_next_header : ?level:Tar.Header.compatibility -> global:Tar.Header.Extended.t option
+    -> in_channel -> (Tar.Header.t * Tar.Header.Extended.t option) Async.t
 
   val really_read : in_channel -> Cstruct.t -> unit Async.t
   (** [really_read fd buf] fills [buf] with data from [fd] or raises
@@ -48,8 +48,8 @@ module Make
   val of_out_channel : ?bits:int -> ?q:int -> level:int ->
     mtime:int32 -> Gz.os -> Writer.out_channel -> out_channel
 
-  val write_block : ?level:Tar.Header.compatibility -> Tar.Header.t ->
-    out_channel -> (unit -> string option Async.t) -> unit Async.t
+  val write_block : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t ->
+    Tar.Header.t -> out_channel -> (unit -> string option Async.t) -> unit Async.t
   (** [write_block hdr oc stream] writes [hdr], then {i deflate} the given
       [stream], then zero-pads so the stream is positionned for the next
       block.

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,5 +1,5 @@
 (tests
- (names parse_test write_test allocate_set_partial_test)
+ (names parse_test write_test allocate_set_partial_test global_extended_headers_test)
  (package tar-mirage)
  (libraries
   mirage-block-unix

--- a/lib_test/global_extended_headers_test.ml
+++ b/lib_test/global_extended_headers_test.ml
@@ -81,7 +81,7 @@ let use_global_extended_headers _test_ctxt =
     let pp ppf hdr = Fmt.pf ppf "%s" (Tar.Header.Extended.to_detailed_string hdr) in
     Alcotest.testable (fun ppf hdr -> Fmt.pf ppf "%a" Fmt.(option pp) hdr) ( = )
   in
-  ( match HR.read ~level ?global:!global cin with
+  ( match HR.read ~level ~global:!global cin with
     | Ok (hdr, global') ->
        Alcotest.check header "expected global header" (Some g0) global';
        global := global';
@@ -89,7 +89,7 @@ let use_global_extended_headers _test_ctxt =
        let to_skip = Tar.Header.(Int64.to_int (to_sectors hdr) * length) in
        Reader.skip cin to_skip;
     | Error `Eof -> failwith "Couldn't read header" );
-  ( match HR.read ~level ?global:!global cin with
+  ( match HR.read ~level ~global:!global cin with
     | Ok (hdr, global') ->
        Alcotest.check header "expected global header" (Some g0) global';
        global := global';
@@ -97,7 +97,7 @@ let use_global_extended_headers _test_ctxt =
        let to_skip = Tar.Header.(Int64.to_int (to_sectors hdr) * length) in
        Reader.skip cin to_skip;
     | Error `Eof -> failwith "Couldn't read header" );
-  ( match HR.read ~level ?global:!global cin with
+  ( match HR.read ~level ~global:!global cin with
     | Ok (hdr, global') ->
        Alcotest.check header "expected global header" (Some g0) global';
        global := global';
@@ -105,7 +105,7 @@ let use_global_extended_headers _test_ctxt =
        let to_skip = Tar.Header.(Int64.to_int (to_sectors hdr) * length) in
        Reader.skip cin to_skip;
     | Error `Eof -> failwith "Couldn't read header" );
-  ( match HR.read ~level ?global:!global cin with
+  ( match HR.read ~level ~global:!global cin with
     | Ok (hdr, global') ->
        Alcotest.check header "expected global header" (Some g1) global';
        global := global';
@@ -113,7 +113,7 @@ let use_global_extended_headers _test_ctxt =
        let to_skip = Tar.Header.(Int64.to_int (to_sectors hdr) * length) in
        Reader.skip cin to_skip;
     | Error `Eof -> failwith "Couldn't read header" );
-  ( match HR.read ~level ?global:!global cin with
+  ( match HR.read ~level ~global:!global cin with
     | Ok _ -> failwith "Should have found EOF"
     | Error `Eof -> () );
   ()

--- a/lib_test/global_extended_headers_test.ml
+++ b/lib_test/global_extended_headers_test.ml
@@ -1,0 +1,126 @@
+let level = Tar.Header.Ustar
+
+module Writer = struct
+  type out_channel = Stdlib.out_channel
+  type 'a t = 'a
+  let really_write oc cs =
+    let str = Cstruct.to_string cs in
+    output_string oc str
+end
+
+module HW = Tar.HeaderWriter
+  (struct type 'a t = 'a
+          let ( >>= ) x f = f x
+          let return x = x end)
+  (Writer)
+
+module Reader = struct
+  type in_channel = Stdlib.in_channel
+  type 'a t = 'a
+  let really_read ic cs =
+    let len = Cstruct.length cs in
+    let buf = Bytes.create len in
+    really_input ic buf 0 len ;
+    Cstruct.blit_from_bytes buf 0 cs 0 len
+  let skip ic len = really_read ic (Cstruct.create len)
+  let read ic cs =
+    let max = Cstruct.length cs in
+    let buf = Bytes.create max in
+    let len = input ic buf 0 max in
+    Cstruct.blit_from_bytes buf 0 cs 0 len ; len
+end
+
+module HR = Tar.HeaderReader
+  (struct type 'a t = 'a
+          let ( >>= ) x f = f x
+          let return x = x end)
+  (Reader)
+
+let make_extended user_id =
+  Tar.Header.Extended.make ~user_id ()
+
+let make_file =
+  let gen = ref 0 in
+  fun () ->
+  let name = "file" ^ string_of_int !gen in
+  incr gen;
+  let hdr = Tar.Header.make name 0L in
+  hdr, fun cout ->
+       Tar.Header.zero_padding hdr
+       |> Cstruct.to_string
+       |> output_string cout
+
+(* Tests that global and per-file extended headers correctly override
+   each other. *)
+let use_global_extended_headers _test_ctxt =
+  (* Write an archive using global and per-file pax extended headers *)
+  begin try Sys.remove "test.tar" with _ -> () end;
+  let cout = open_out_bin "test.tar" in
+  let g0 = make_extended 1000 in
+  let hdr, f = make_file () in
+  HW.write ~level ~global:g0 hdr cout;
+  f cout;
+  let hdr, f = make_file () in
+  let hdr = { hdr with Tar.Header.extended = Some (make_extended 2000) } in
+  HW.write ~level hdr cout;
+  f cout;
+  let hdr, f = make_file () in
+  HW.write ~level hdr cout;
+  f cout;
+  let g1 = make_extended 3000 in
+  let hdr, f = make_file () in
+  HW.write ~level ~global:g1 hdr cout;
+  f cout;
+  Writer.really_write cout Tar.Header.zero_block;
+  Writer.really_write cout Tar.Header.zero_block;
+  close_out cout;
+  (* Read the same archive, testing that headers have been squashed. *)
+  let cin = open_in_bin "test.tar" in
+  let global = ref None in
+  let header =
+    let pp ppf hdr = Fmt.pf ppf "%s" (Tar.Header.Extended.to_detailed_string hdr) in
+    Alcotest.testable (fun ppf hdr -> Fmt.pf ppf "%a" Fmt.(option pp) hdr) ( = )
+  in
+  ( match HR.read ~level ?global:!global cin with
+    | Ok (hdr, global') ->
+       Alcotest.check header "expected global header" (Some g0) global';
+       global := global';
+       Alcotest.(check int) "expected user" 1000 hdr.Tar.Header.user_id;
+       let to_skip = Tar.Header.(Int64.to_int (to_sectors hdr) * length) in
+       Reader.skip cin to_skip;
+    | Error `Eof -> failwith "Couldn't read header" );
+  ( match HR.read ~level ?global:!global cin with
+    | Ok (hdr, global') ->
+       Alcotest.check header "expected global header" (Some g0) global';
+       global := global';
+       Alcotest.(check int) "expected user" 2000 hdr.Tar.Header.user_id;
+       let to_skip = Tar.Header.(Int64.to_int (to_sectors hdr) * length) in
+       Reader.skip cin to_skip;
+    | Error `Eof -> failwith "Couldn't read header" );
+  ( match HR.read ~level ?global:!global cin with
+    | Ok (hdr, global') ->
+       Alcotest.check header "expected global header" (Some g0) global';
+       global := global';
+       Alcotest.(check int) "expected user" 1000 hdr.Tar.Header.user_id;
+       let to_skip = Tar.Header.(Int64.to_int (to_sectors hdr) * length) in
+       Reader.skip cin to_skip;
+    | Error `Eof -> failwith "Couldn't read header" );
+  ( match HR.read ~level ?global:!global cin with
+    | Ok (hdr, global') ->
+       Alcotest.check header "expected global header" (Some g1) global';
+       global := global';
+       Alcotest.(check int) "expected user" 3000 hdr.Tar.Header.user_id;
+       let to_skip = Tar.Header.(Int64.to_int (to_sectors hdr) * length) in
+       Reader.skip cin to_skip;
+    | Error `Eof -> failwith "Couldn't read header" );
+  ( match HR.read ~level ?global:!global cin with
+    | Ok _ -> failwith "Should have found EOF"
+    | Error `Eof -> () );
+  ()
+
+let () =
+  let suite = "tar - pax global extended headers", [
+      Alcotest.test_case "can use pax global extended headers" `Quick use_global_extended_headers;
+    ]
+  in
+  Alcotest.run "global extended headers" [suite]

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -156,7 +156,7 @@ let can_transform_tar () =
   Unix.close fd_in;
   Unix.close fd_out;
   let fd_in = Unix.openfile tar_out [ O_RDONLY; O_CLOEXEC ] 0 in
-  Tar_unix.Archive.with_next_file fd_in (fun fd_file _global hdr ->
+  Tar_unix.Archive.with_next_file fd_in ~global:None (fun fd_file _global hdr ->
       Alcotest.(check string) "Filename was transformed" temp_dir
         (String.sub hdr.file_name 0 (min (String.length hdr.file_name) (String.length temp_dir)));
       Tar_unix.Archive.skip fd_file (Int64.to_int hdr.file_size));

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -156,7 +156,7 @@ let can_transform_tar () =
   Unix.close fd_in;
   Unix.close fd_out;
   let fd_in = Unix.openfile tar_out [ O_RDONLY; O_CLOEXEC ] 0 in
-  Tar_unix.Archive.with_next_file fd_in (fun fd_file hdr ->
+  Tar_unix.Archive.with_next_file fd_in (fun fd_file _global hdr ->
       Alcotest.(check string) "Filename was transformed" temp_dir
         (String.sub hdr.file_name 0 (min (String.length hdr.file_name) (String.length temp_dir)));
       Tar_unix.Archive.skip fd_file (Int64.to_int hdr.file_size));

--- a/mirage/tar_mirage.ml
+++ b/mirage/tar_mirage.ml
@@ -255,8 +255,8 @@ module Make_KV_RO (BLOCK : Mirage_block.S) = struct
     if ssize mod 512 <> 0 || ssize < 512 then
       invalid_arg "Sector size needs to be >= 512 and a multiple of 512";
     let in_channel = { Reader.b; offset = 0L; info } in
-    let rec loop ?global map =
-      HR.read ?global in_channel >>= function
+    let rec loop ~global map =
+      HR.read ~global in_channel >>= function
       | Error `Eof -> Lwt.return map
       | Ok (tar, global) ->
         let filename = trim_slash tar.Tar.Header.file_name in
@@ -270,10 +270,10 @@ module Make_KV_RO (BLOCK : Mirage_block.S) = struct
         in
         Reader.skip in_channel (Int64.to_int tar.Tar.Header.file_size) >>= fun () ->
         Reader.skip in_channel (Tar.Header.compute_zero_padding_length tar) >>= fun () ->
-        loop ?global map
+        loop ~global map
     in
     let root = StringMap.empty in
-    loop root >>= fun map ->
+    loop ~global:None root >>= fun map ->
     (* This is after the two [zero_block]s *)
     let end_of_archive = in_channel.Reader.offset in
     let map = Dict (Tar.Header.make "/" 0L, map) in

--- a/mirage/tar_mirage.ml
+++ b/mirage/tar_mirage.ml
@@ -255,10 +255,10 @@ module Make_KV_RO (BLOCK : Mirage_block.S) = struct
     if ssize mod 512 <> 0 || ssize < 512 then
       invalid_arg "Sector size needs to be >= 512 and a multiple of 512";
     let in_channel = { Reader.b; offset = 0L; info } in
-    let rec loop map =
-      HR.read in_channel >>= function
+    let rec loop ?global map =
+      HR.read ?global in_channel >>= function
       | Error `Eof -> Lwt.return map
-      | Ok tar ->
+      | Ok (tar, global) ->
         let filename = trim_slash tar.Tar.Header.file_name in
         let map =
           if filename = "" then
@@ -270,7 +270,7 @@ module Make_KV_RO (BLOCK : Mirage_block.S) = struct
         in
         Reader.skip in_channel (Int64.to_int tar.Tar.Header.file_size) >>= fun () ->
         Reader.skip in_channel (Tar.Header.compute_zero_padding_length tar) >>= fun () ->
-        loop map
+        loop ?global map
     in
     let root = StringMap.empty in
     loop root >>= fun map ->

--- a/unix/tar_lwt_unix.mli
+++ b/unix/tar_lwt_unix.mli
@@ -28,7 +28,7 @@ val really_write: Lwt_unix.file_descr -> Cstruct.t -> unit Lwt.t
     zero-filled blocks are discovered. Assumes stream is positioned at the
     possible start of a header block.
     @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
-val get_next_header : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t -> Lwt_unix.file_descr ->
+val get_next_header : ?level:Tar.Header.compatibility -> global:Tar.Header.Extended.t option -> Lwt_unix.file_descr ->
                       (Tar.Header.t * Tar.Header.Extended.t option) option Lwt.t
 
 (** Return the header needed for a particular file on disk. *)
@@ -40,7 +40,7 @@ module Archive : sig
   (** Read the next header, apply the function 'f' to the fd and the header. The function
       should leave the fd positioned immediately after the datablock. Finally the function
       skips past the zero padding to the next header. *)
-  val with_next_file : Lwt_unix.file_descr -> ?global:Tar.Header.Extended.t ->
+  val with_next_file : Lwt_unix.file_descr -> global:Tar.Header.Extended.t option ->
                        (Lwt_unix.file_descr -> Tar.Header.Extended.t option -> Tar.Header.t -> 'a Lwt.t) -> 'a option Lwt.t
 
   (** List the contents of a tar to stdout. *)

--- a/unix/tar_lwt_unix.mli
+++ b/unix/tar_lwt_unix.mli
@@ -28,7 +28,8 @@ val really_write: Lwt_unix.file_descr -> Cstruct.t -> unit Lwt.t
     zero-filled blocks are discovered. Assumes stream is positioned at the
     possible start of a header block.
     @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
-val get_next_header : ?level:Tar.Header.compatibility -> Lwt_unix.file_descr -> Tar.Header.t option Lwt.t
+val get_next_header : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t -> Lwt_unix.file_descr ->
+                      (Tar.Header.t * Tar.Header.Extended.t option) option Lwt.t
 
 (** Return the header needed for a particular file on disk. *)
 val header_of_file : ?level:Tar.Header.compatibility -> string -> Tar.Header.t Lwt.t
@@ -39,7 +40,8 @@ module Archive : sig
   (** Read the next header, apply the function 'f' to the fd and the header. The function
       should leave the fd positioned immediately after the datablock. Finally the function
       skips past the zero padding to the next header. *)
-  val with_next_file : Lwt_unix.file_descr -> (Lwt_unix.file_descr -> Tar.Header.t -> 'a Lwt.t) -> 'a option Lwt.t
+  val with_next_file : Lwt_unix.file_descr -> ?global:Tar.Header.Extended.t ->
+                       (Lwt_unix.file_descr -> Tar.Header.Extended.t option -> Tar.Header.t -> 'a Lwt.t) -> 'a option Lwt.t
 
   (** List the contents of a tar to stdout. *)
   val list : ?level:Tar.Header.compatibility -> Lwt_unix.file_descr -> Tar.Header.t list Lwt.t

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -93,14 +93,14 @@ module Archive = struct
 
   let transform ?level f ifd ofd =
     let rec loop global () =
-      match get_next_header ?global ifd with
+      match get_next_header ~global ifd with
       | exception Tar.Header.End_of_stream -> ()
-      | (header', global) ->
+      | (header', global') ->
         let header = f header' in
         let body = fun _ -> copy_n ifd ofd header.Tar.Header.file_size in
-        write_block ?level header body ofd;
+        write_block ?level ?global:(if global <> global' then global' else None) header body ofd;
         skip ifd (Tar.Header.compute_zero_padding_length header');
-        loop global () in
+        loop global' () in
     loop None ();
     write_end ofd
 

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -92,16 +92,16 @@ module Archive = struct
     extract_gen dest ifd
 
   let transform ?level f ifd ofd =
-    let rec loop () =
-      match get_next_header ifd with
+    let rec loop global () =
+      match get_next_header ?global ifd with
       | exception Tar.Header.End_of_stream -> ()
-      | header' ->
+      | (header', global) ->
         let header = f header' in
         let body = fun _ -> copy_n ifd ofd header.Tar.Header.file_size in
         write_block ?level header body ofd;
         skip ifd (Tar.Header.compute_zero_padding_length header');
-        loop () in
-    loop ();
+        loop global () in
+    loop None ();
     write_end ofd
 
   (** Create a tar on file descriptor fd from the filename list

--- a/unix/tar_unix.mli
+++ b/unix/tar_unix.mli
@@ -28,7 +28,7 @@ val really_write: Unix.file_descr -> Cstruct.t -> unit
     zero-filled blocks are discovered. Assumes stream is positioned at the
     possible start of a header block.
     @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
-val get_next_header : ?level:Tar.Header.compatibility -> Unix.file_descr -> Tar.Header.t
+val get_next_header : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t -> Unix.file_descr -> Tar.Header.t * Tar.Header.Extended.t option
 
 (** Return the header needed for a particular file on disk. *)
 val header_of_file : ?level:Tar.Header.compatibility -> string -> Tar.Header.t
@@ -48,7 +48,7 @@ module Archive : sig
   (** Read the next header, apply the function 'f' to the fd and the header. The function
       should leave the fd positioned immediately after the datablock. Finally the function
       skips past the zero padding to the next header. *)
-  val with_next_file : Unix.file_descr -> (Unix.file_descr -> Tar.Header.t -> 'a) -> 'a
+  val with_next_file : Unix.file_descr -> ?global: Tar.Header.Extended.t -> (Unix.file_descr -> Tar.Header.Extended.t option -> Tar.Header.t -> 'a) -> 'a
 
   (** List the contents of a tar. *)
   val list : ?level:Tar.Header.compatibility -> Unix.file_descr -> Tar.Header.t list

--- a/unix/tar_unix.mli
+++ b/unix/tar_unix.mli
@@ -28,12 +28,14 @@ val really_write: Unix.file_descr -> Cstruct.t -> unit
     zero-filled blocks are discovered. Assumes stream is positioned at the
     possible start of a header block.
     @raise Stdlib.End_of_file if the stream unexpectedly fails. *)
-val get_next_header : ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t -> Unix.file_descr -> Tar.Header.t * Tar.Header.Extended.t option
+val get_next_header : ?level:Tar.Header.compatibility -> global:Tar.Header.Extended.t option ->
+  Unix.file_descr -> Tar.Header.t * Tar.Header.Extended.t option
 
 (** Return the header needed for a particular file on disk. *)
 val header_of_file : ?level:Tar.Header.compatibility -> string -> Tar.Header.t
 
-val write_block: ?level:Tar.Header.compatibility -> Tar.Header.t -> (Unix.file_descr -> unit) -> Unix.file_descr -> unit
+val write_block: ?level:Tar.Header.compatibility -> ?global:Tar.Header.Extended.t ->
+  Tar.Header.t -> (Unix.file_descr -> unit) -> Unix.file_descr -> unit
   [@@ocaml.deprecated "Deprecated in favor of Tar.HeaderWriter"]
   (** Write [hdr], then call [write_body fd] to write the body,
       then zero-pads so the stream is positioned for the next block. *)
@@ -48,7 +50,7 @@ module Archive : sig
   (** Read the next header, apply the function 'f' to the fd and the header. The function
       should leave the fd positioned immediately after the datablock. Finally the function
       skips past the zero padding to the next header. *)
-  val with_next_file : Unix.file_descr -> ?global: Tar.Header.Extended.t -> (Unix.file_descr -> Tar.Header.Extended.t option -> Tar.Header.t -> 'a) -> 'a
+  val with_next_file : Unix.file_descr -> global:Tar.Header.Extended.t option -> (Unix.file_descr -> Tar.Header.Extended.t option -> Tar.Header.t -> 'a) -> 'a
 
   (** List the contents of a tar. *)
   val list : ?level:Tar.Header.compatibility -> Unix.file_descr -> Tar.Header.t list


### PR DESCRIPTION
~Unfinished work.~
PoC for supporting pax global extended headers. They introduce global state, which needs to be threaded to calls to `HR.read`, breaking the API.
~The change is somewhat important, so I haven't completed the work.~
Any thoughts? :-)