### PR TITLE
Remove 'simple' from the library description

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,7 @@
  (name tar)
  (synopsis "Decode and encode tar format files in pure OCaml")
  (description
-"\| tar is a simple library to read and write tar files with an emphasis on
+"\| tar is a library to read and write tar files with an emphasis on
 "\| streaming.
 "\|
 "\| This is pure OCaml code, no C bindings.
@@ -38,7 +38,7 @@
  (name tar-unix)
  (synopsis "Decode and encode tar format files from Unix")
  (description
-"\| tar is a simple library to read and write tar files with an emphasis on
+"\| tar is a library to read and write tar files with an emphasis on
 "\| streaming.  This library provides a Unix or Windows compatible interface.
  )
  (tags ("org:xapi-project" "org:mirage"))
@@ -55,7 +55,7 @@
  (name tar-mirage)
  (synopsis "Read and write tar format files via MirageOS interfaces")
  (description
-"\| tar is a simple library to read and write tar files with an emphasis on
+"\| tar is a library to read and write tar files with an emphasis on
 "\| streaming.  This library is functorised over external OS dependencies
 "\| to facilitate embedding within MirageOS.
  )

--- a/dune-project
+++ b/dune-project
@@ -13,7 +13,9 @@
  "David Allsopp"
  "Antonin Décimo"
 )
-(maintainers "dave@recoil.org")
+(maintainers
+  "Reynir Björnsson <reynir@reynir.dk>"
+  "dave@recoil.org")
 (documentation "https://mirage.github.io/ocaml-tar/")
 
 (package

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -6,7 +6,7 @@ tar is a library to read and write tar files with an emphasis on
 streaming.  This library is functorised over external OS dependencies
 to facilitate embedding within MirageOS.
 """
-maintainer: ["dave@recoil.org"]
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
 authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
 license: "ISC"
 tags: ["org:xapi-project" "org:mirage"]

--- a/tar-mirage.opam
+++ b/tar-mirage.opam
@@ -2,7 +2,7 @@
 opam-version: "2.0"
 synopsis: "Read and write tar format files via MirageOS interfaces"
 description: """
-tar is a simple library to read and write tar files with an emphasis on
+tar is a library to read and write tar files with an emphasis on
 streaming.  This library is functorised over external OS dependencies
 to facilitate embedding within MirageOS.
 """

--- a/tar-unix.opam
+++ b/tar-unix.opam
@@ -2,7 +2,7 @@
 opam-version: "2.0"
 synopsis: "Decode and encode tar format files from Unix"
 description: """
-tar is a simple library to read and write tar files with an emphasis on
+tar is a library to read and write tar files with an emphasis on
 streaming.  This library provides a Unix or Windows compatible interface.
 """
 maintainer: ["dave@recoil.org"]

--- a/tar-unix.opam
+++ b/tar-unix.opam
@@ -5,7 +5,7 @@ description: """
 tar is a library to read and write tar files with an emphasis on
 streaming.  This library provides a Unix or Windows compatible interface.
 """
-maintainer: ["dave@recoil.org"]
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
 authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
 license: "ISC"
 tags: ["org:xapi-project" "org:mirage"]

--- a/tar.opam
+++ b/tar.opam
@@ -2,7 +2,7 @@
 opam-version: "2.0"
 synopsis: "Decode and encode tar format files in pure OCaml"
 description: """
-tar is a simple library to read and write tar files with an emphasis on
+tar is a library to read and write tar files with an emphasis on
 streaming.
 
 This is pure OCaml code, no C bindings.

--- a/tar.opam
+++ b/tar.opam
@@ -7,7 +7,7 @@ streaming.
 
 This is pure OCaml code, no C bindings.
 """
-maintainer: ["dave@recoil.org"]
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
 authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
 license: "ISC"
 tags: ["org:xapi-project" "org:mirage"]


### PR DESCRIPTION
It is different from person to person what is a 'simple' library. Thus it doesn't convey much at best, and at worst it can be very demotivating if you struggle understanding the 'simple' library.