### PR TITLE
tar-eio: require ocaml 5.0+

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -91,7 +91,7 @@
  )
  (tags ("org:xapi-project" "org:mirage"))
  (depends
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 5.00.0))
   (eio (and (>= 0.10.0) (< 0.12)))
   (tar (= :version))
  )

--- a/tar-eio.opam
+++ b/tar-eio.opam
@@ -21,7 +21,7 @@ doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "5.00.0"}
   "eio" {>= "0.10.0" & < "0.12"}
   "tar" {= version}
   "odoc" {with-doc}


### PR DESCRIPTION
as suggested by @talex5 in https://github.com/mirage/ocaml-tar/pull/132#issuecomment-1884843952