### PR TITLE
remove ref to compatibility level

### DIFF
--- a/eio/tar_eio.ml
+++ b/eio/tar_eio.ml
@@ -62,7 +62,7 @@ let stat path =
 
 (** Return the header needed for a particular file on disk *)
 let header_of_file ?level ?getpwuid ?getgrgid filepath : Tar.Header.t =
-  let level = match level with None -> !Tar.Header.compatibility_level | Some level -> level in
+  let level = Tar.Header.compatibility level in
   let stat = stat filepath in
   let pwent = Option.map (fun f -> f stat.uid) getpwuid in
   let grent = Option.map (fun f -> f stat.gid) getgrgid in

--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -36,8 +36,8 @@ module Header : sig
     | Ustar (** POSIX.1-1988 *)
     | Posix (** POSIX.1-2001 *)
 
-  (** Default compatibility if [?level] is omitted. Defaults to {!V7}. *)
-  val compatibility_level : compatibility ref
+  (** Return the compatibility level, defaults to {!V7}. *)
+  val compatibility : compatibility option -> compatibility
 
   module Link : sig
     (** Determines the type of the file. *)

--- a/unix/tar_lwt_unix.ml
+++ b/unix/tar_lwt_unix.ml
@@ -52,7 +52,7 @@ module HeaderWriter = Tar.HeaderWriter(Lwt)(Io)
 
 (** Return the header needed for a particular file on disk *)
 let header_of_file ?level (file: string) : Tar.Header.t Lwt.t =
-  let level = match level with None -> !Tar.Header.compatibility_level | Some level -> level in
+  let level = Tar.Header.compatibility level in
   Lwt_unix.LargeFile.stat file >>= fun stat ->
   Lwt_unix.getpwuid stat.Lwt_unix.LargeFile.st_uid >>= fun pwent ->
   Lwt_unix.getgrgid stat.Lwt_unix.LargeFile.st_gid >>= fun grent ->

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -58,7 +58,7 @@ include Driver
 
   (** Return the header needed for a particular file on disk *)
 let header_of_file ?level (file: string) : Tar.Header.t =
-  let level = match level with None -> !Tar.Header.compatibility_level | Some level -> level in
+  let level = Tar.Header.compatibility level in
   let stat = Unix.LargeFile.lstat file in
   let file_mode = stat.Unix.LargeFile.st_perm in
   let user_id = stat.Unix.LargeFile.st_uid in


### PR DESCRIPTION
This avoids mutable state in the core (Tar.Header) API.