### PR TITLE
Expose Tar_lwt_unix.run

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -46,7 +46,7 @@
  (tags ("org:xapi-project" "org:mirage"))
  (depends
   (ocaml (>= 4.08.0))
-  lwt
+  (lwt (>= 5.7.0))
   (tar (= :version))
  )
 )

--- a/unix/tar_lwt_unix.mli
+++ b/unix/tar_lwt_unix.mli
@@ -27,6 +27,8 @@ val pp_decode_error : Format.formatter -> decode_error -> unit
 
 type t
 
+val run : ('a, [> decode_error ] as 'b, t) Tar.t -> Lwt_unix.file_descr ->
+  ('a, 'b) result Lwt.t
 val value : ('a, 'err) result Lwt.t -> ('a, 'err, t) Tar.t
 
 (** [fold f filename acc] folds over the tar archive. The function [f] is called


### PR DESCRIPTION
The `run` function is exposed in `Tar_unix` as well as `Tar_eio` so clearly an omission.

See also #148.