### PR TITLE
Document probable bugs with tar_lwt_unix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_opam/
 _build/
 *.install
 *.merlin

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,8 @@
+(executable
+ (name regress_targz)
+ (libraries str tar.gz tar_unix))
+
 (cram
  (package tar-unix)
  (enabled_if (= %{os_type} "Unix"))
- (deps %{bin:otar}))
+ (deps %{bin:otar} regress_targz.exe))

--- a/test/regress_targz.ml
+++ b/test/regress_targz.ml
@@ -1,0 +1,131 @@
+let test_filter : Tar.Header.t -> bool =
+  let search_for = Str.regexp ".*/openapi/spec3.json$" in
+  fun { file_name; _ } ->
+    match Str.search_forward search_for file_name with
+    | exception Not_found -> false
+    | _ -> true
+
+module TestExtract = struct
+  let do_test filename =
+    let open Lwt.Infix in
+    Tar_lwt_unix.extract ~filter:test_filter ~src:filename "extracted/"
+    >>= function
+    | Ok v -> Lwt.return v
+    | Error (`Gz msg) ->
+        Format.kasprintf failwith "Gzip decompression failed. %s" msg
+    | Error `Eof -> failwith "End of file reached."
+    | Error (`Exn e) -> raise e
+    | Error ((`Fatal _ | `Unix _ | `Unexpected_end_of_file | `Msg _) as e) ->
+        Format.kasprintf failwith "Could not find entry. %a"
+          Tar_lwt_unix.pp_decode_error e
+end
+
+module TestUntar = struct
+  let max_int_64 = Int64.of_int Int.max_int
+
+  let max_string_64 =
+    (* https://ocaml.org/manual/4.14/values.html *)
+    if Sys.int_size > 32 then
+      let open Int64 in
+      (* 2^57 - 9 = 144115188075855863L *)
+      sub (shift_left (of_int 1) 57) 9L
+    else (* 2^24 − 5 *)
+      Int64.of_int 16777211
+
+  let safe f a =
+    let open Lwt.Infix in
+    Lwt.catch
+      (fun () -> f a >|= fun r -> Ok r)
+      (function
+        | Unix.Unix_error (e, f, a) -> Lwt.return (Error (`Unix (e, f, a)))
+        | e -> Lwt.reraise e)
+
+  let safe_close fd =
+    Lwt.catch (fun () -> Lwt_unix.close fd) (fun _ -> Lwt.return_unit)
+
+  let fold ~gunzip f filename init =
+    let open Lwt_result.Infix in
+    let decompress = if gunzip then Tar_gz.in_gzipped else Fun.id in
+    safe Lwt_unix.(openfile filename [ O_RDONLY ]) 0 >>= fun fd ->
+    Lwt.finalize
+      (fun () -> Tar_lwt_unix.run (decompress (Tar.fold f init)) fd)
+      (fun () -> safe_close fd)
+
+  let find_entry_aux :
+      ?global:Tar.Header.Extended.t ->
+      Tar.Header.t ->
+      'a ->
+      ( 'a,
+        ([> `Eof
+         | `Fatal of Tar.error
+         | `Gz of string
+         | `Msg of string
+         | `Unexpected_end_of_file
+         | `Unix of Unix.error * string * string ]
+         as
+         'b),
+        Tar_lwt_unix.t )
+      Tar.t =
+   fun ?global:_ hdr acc ->
+    match acc with
+    | Some found -> Tar.return (Ok (Some found))
+    | None ->
+        let ( let* ) = Tar.( let* ) in
+        if test_filter hdr then
+          (* Found entry *)
+          let* entry_len =
+            match hdr.Tar.Header.file_size with
+            | n when n <= max_string_64 -> Tar.return (Ok (Int64.to_int n))
+            | _ ->
+                Tar.return
+                  (Error
+                     (`Msg
+                       (Format.asprintf
+                          "The tar entry %s exceeded the architecture-specific \
+                           maximum %d bytes that fit in an in-memory string."
+                          hdr.file_name Int.max_int)))
+          in
+          let* entry_content = Tar.really_read entry_len in
+          Tar.return (Ok (Some entry_content))
+        else
+          (* Did not find entry *)
+          let rec skip_until = function
+            | n when n <= max_int_64 -> Tar.seek (Int64.to_int n)
+            | n ->
+                let* _ = Tar.seek Int.max_int in
+                skip_until (Int64.sub n max_int_64)
+          in
+          let* _ = skip_until hdr.Tar.Header.file_size in
+          Tar.return (Ok None)
+
+  let find_entry_opt ~gunzip filename =
+    let open Lwt.Infix in
+    fold ~gunzip find_entry_aux filename None >>= function
+    | Ok v -> Lwt.return v
+    | Error (`Gz msg) ->
+        Format.kasprintf failwith "Gzip decompression failed. %s" msg
+    | Error `Eof -> failwith "End of file reached."
+    | Error ((`Fatal _ | `Unix _ | `Unexpected_end_of_file | `Msg _) as e) ->
+        Format.kasprintf failwith "Could not find entry. %a"
+          Tar_lwt_unix.pp_decode_error e
+
+  let do_test ~gunzip filename =
+    let open Lwt.Infix in
+    find_entry_opt ~gunzip filename >>= function
+    | Some entry ->
+        Printf.printf "Found /openapi/spec3.json entry. Size = %d\n"
+          (String.length entry);
+        Lwt.return ()
+    | None -> failwith "No /openapi/spec3.json found"
+end
+
+let () =
+  let filename = Sys.argv.(1) in
+  let test =
+    match Sys.argv.(2) with
+    | "untar" -> TestUntar.do_test ~gunzip:false filename
+    | "untargz" -> TestUntar.do_test ~gunzip:true filename
+    | "extract" -> TestExtract.do_test filename
+    | _ -> failwith "Must be untar/untargz/extract"
+  in
+  Lwt_main.run test

--- a/test/regress_targz.ml
+++ b/test/regress_targz.ml
@@ -1,7 +1,7 @@
 let test_filter : Tar.Header.t -> bool =
   let search_for = Str.regexp ".*/openapi/spec3.json$" in
   fun { file_name; _ } ->
-    match Str.search_forward search_for file_name with
+    match Str.search_forward search_for file_name 0 with
     | exception Not_found -> false
     | _ -> true
 

--- a/test/targz.t
+++ b/test/targz.t
@@ -1,0 +1,75 @@
+TEST SUITE
+----------
+
+Test downloading https://github.com/stripe/openapi/archive/refs/tags/v1044.tar.gz
+and extracting openapi/spec3.json in one of three ways:
+A. "Extract"-ing it in OCaml
+B. Decompressing in Unix, and then untarring it in OCaml
+C. Decompressing and untarring it in OCaml
+
+Download v1044.tar.gz
+  $ curl -s -L -o v1044.tar.gz https://github.com/stripe/openapi/archive/refs/tags/v1044.tar.gz
+  $ wc -c v1044.tar.gz
+  4307906 v1044.tar.gz
+
+Uncompress it
+_     (fun () -> Tar_lwt_unix.run (decompress (Tar.fold f init)) fd)
+_  in regress_targz.ml:fold works when `decompress = Fun.id`
+  $ gunzip -c v1044.tar.gz > v1044.tar
+  $ wc -c v1044.tar
+  42301440 v1044.tar
+
+A. "Extract"-ing it in OCaml.
+That is, TestExtract.do_test
+  $ OCAMLRUNPARAM=b ./regress_targz.exe v1044.tar extract
+  Fatal error: exception Invalid_argument("Lwt_unix.read")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from Tar_lwt_unix.safe.(fun) in file "unix/tar_lwt_unix.ml", line 38, characters 15-18
+  Called from Lwt.Sequential_composition.catch in file "src/core/lwt.ml", line 2016, characters 10-14
+  Re-raised at Tar_lwt_unix.safe.(fun) in file "unix/tar_lwt_unix.ml", line 41, characters 13-26
+  Called from Tar_lwt_unix.read_complete.loop in file "unix/tar_lwt_unix.ml", line 47, characters 6-55
+  Called from Tar_lwt_unix.run.run in file "unix/tar_lwt_unix.ml", line 99, characters 6-44
+  Called from Tar_lwt_unix.run.run in file "unix/tar_lwt_unix.ml", line 105, characters 6-11
+  Called from Lwt.Sequential_composition.bind.create_result_promise_and_callback_if_deferred.callback in file "src/core/lwt.ml", line 1844, characters 16-19
+  Re-raised at Lwt.Miscellaneous.poll in file "src/core/lwt.ml", line 3123, characters 20-29
+  Called from Lwt_main.run.run_loop in file "src/unix/lwt_main.ml", line 27, characters 10-20
+  Called from Lwt_main.run in file "src/unix/lwt_main.ml", line 106, characters 8-13
+  Re-raised at Lwt_main.run in file "src/unix/lwt_main.ml", line 112, characters 4-13
+  Called from Dune__exe__Regress_targz in file "test/regress_targz.ml", line 131, characters 2-19
+  [2]
+
+B. Decompressing in Unix, and then untarring it in OCaml.
+That is, TestUntar.do_test ~gunzip:false where ...
+_     (fun () -> Tar_lwt_unix.run (decompress (Tar.fold f init)) fd)
+in regress_targz.ml:fold works when `decompress = Fun.id`
+  $ OCAMLRUNPARAM=b ./regress_targz.exe v1044.tar untar
+  Fatal error: exception Invalid_argument("Lwt_unix.read")
+  Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
+  Called from Tar_lwt_unix.safe.(fun) in file "unix/tar_lwt_unix.ml", line 38, characters 15-18
+  Called from Lwt.Sequential_composition.catch in file "src/core/lwt.ml", line 2016, characters 10-14
+  Re-raised at Tar_lwt_unix.safe.(fun) in file "unix/tar_lwt_unix.ml", line 41, characters 13-26
+  Called from Tar_lwt_unix.read_complete.loop in file "unix/tar_lwt_unix.ml", line 47, characters 6-55
+  Called from Tar_lwt_unix.run.run in file "unix/tar_lwt_unix.ml", line 99, characters 6-44
+  Called from Tar_lwt_unix.run.run in file "unix/tar_lwt_unix.ml", line 105, characters 6-11
+  Called from Lwt.Sequential_composition.bind.create_result_promise_and_callback_if_deferred.callback in file "src/core/lwt.ml", line 1844, characters 16-19
+  Re-raised at Lwt.Miscellaneous.poll in file "src/core/lwt.ml", line 3123, characters 20-29
+  Called from Lwt_main.run.run_loop in file "src/unix/lwt_main.ml", line 27, characters 10-20
+  Called from Lwt_main.run in file "src/unix/lwt_main.ml", line 106, characters 8-13
+  Re-raised at Lwt_main.run in file "src/unix/lwt_main.ml", line 112, characters 4-13
+  Called from Dune__exe__Regress_targz in file "test/regress_targz.ml", line 131, characters 2-19
+  [2]
+
+C. Decompressing and untarring it in OCaml.
+That is, TestUntar.do_test ~gunzip:true where ...
+_     (fun () -> Tar_lwt_unix.run (decompress (Tar.fold f init)) fd)
+in regress_targz.ml:fold works when `decompress = Tar_gz.in_gzipped`
+  $ OCAMLRUNPARAM=b ./regress_targz.exe v1044.tar.gz untargz
+  Fatal error: exception Failure("Could not find entry. unmarshal Int64.of_string: failed to parse int64 \"0o0erated c\"")
+  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+  Called from Lwt.Sequential_composition.bind.create_result_promise_and_callback_if_deferred.callback in file "src/core/lwt.ml", line 1844, characters 16-19
+  Re-raised at Lwt.Miscellaneous.poll in file "src/core/lwt.ml", line 3123, characters 20-29
+  Called from Lwt_main.run.run_loop in file "src/unix/lwt_main.ml", line 27, characters 10-20
+  Called from Lwt_main.run in file "src/unix/lwt_main.ml", line 106, characters 8-13
+  Re-raised at Lwt_main.run in file "src/unix/lwt_main.ml", line 112, characters 4-13
+  Called from Dune__exe__Regress_targz in file "test/regress_targz.ml", line 131, characters 2-19
+  [2]


### PR DESCRIPTION
I added in some test cases because I have not been able to get `ocaml-tar` working after version 3. (It was working in version 2, although the API was signficantly different so difficult to compare code directly).

The first test (**A**) is the simplest ... it just calls `Tar_lwt_unix.extract ~filter:test_filter ~src:filename "extracted/"` but even that fails. See `targz.t` for the captured errors and a description of the other two more complicated tests. (I ran on a Windows machine, but I've seen failures on Linux + macOS).

NOTE: There will be different failures on ocaml-ci because they run in a sandbox ... I didn't want to check in a 4 MB .tar.gz so it is downloaded during the tests. So, please test on a desktop with `dune build -p tar,tar-unix '@runtest'` using no sandboxes.