### PR TITLE
Update Tar_(lwt_)unix.extract documentation

### DIFF
--- a/unix/tar_lwt_unix.mli
+++ b/unix/tar_lwt_unix.mli
@@ -40,9 +40,10 @@ val fold :
   string -> 'a -> ('a, 'err) result Lwt.t
 
 (** [extract ~filter ~src dst] extracts the tar archive [src] into the
-    directory [dst]. If [dst] does not exist, it is created. If [filter] is
-    provided (defaults to [fun _ -> true]), any file where [filter hdr] returns
-    [false], is skipped. *)
+    directory [dst]. If [filter] is provided (defaults to [fun _ -> true]), any
+    file where [filter hdr] returns [false], is skipped. No directories are
+    created including [dst] and any (implicit or explicit) directories in the
+    archive. *)
 val extract :
   ?filter:(Tar.Header.t -> bool) ->
   src:string -> string ->

--- a/unix/tar_unix.mli
+++ b/unix/tar_unix.mli
@@ -39,9 +39,10 @@ val fold :
   string -> 'a -> ('a, error) result
 
 (** [extract ~filter ~src dst] extracts the tar archive [src] into the
-    directory [dst]. If [dst] does not exist, it is created. If [filter] is
-    provided (defaults to [fun _ -> true]), any file where [filter hdr] returns
-    [false], is skipped. *)
+    directory [dst]. If [filter] is provided (defaults to [fun _ -> true]), any
+    file where [filter hdr] returns [false], is skipped. No directories are
+    created including [dst] and any (implicit or explicit) directories in the
+    archive. *)
 val extract :
   ?filter:(Tar.Header.t -> bool) ->
   src:string -> string ->


### PR DESCRIPTION
The documentation said it would create [dst]. It did not. In fact, it does not attempt to create *any* directories; not even the ones listed in the archive explicitly or implicitly.

I think it *should* at least create the directories from the archive. #149 touched the same code (somewhat). In the meantime it's better to reflect what it actually does.