### PR TITLE
Tar.out: default to level if entry has None level

### DIFF
--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -890,7 +890,12 @@ let out ?level ?global_hdr entries =
     | None ->
       let* () = writev [ Header.zero_block; Header.zero_block ] in
       return (Ok ())
-    | Some (level, hdr, stream) ->
+    | Some (level', hdr, stream) ->
+      let level =
+        match level' with
+        | Some _ as level -> level
+        | None -> level
+      in
       match encode_header ?level hdr with
       | Ok sstr ->
         let* () = writev sstr in


### PR DESCRIPTION
This may be a confusion about the api. I don't understand why we have a level at Tar.out *and* one for each entry?! maybe @dinosaure knows the intent