### PR TITLE
Update Tar_eio

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -89,7 +89,7 @@
  (tags ("org:xapi-project" "org:mirage"))
  (depends
   (ocaml (>= 5.00.0))
-  (eio (and (>= 1.1) (< 1.2)))
+  (eio (and (>= 1.1)))
   (tar (= :version))
  )
 )

--- a/eio/tar_eio.ml
+++ b/eio/tar_eio.ml
@@ -16,7 +16,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Eio
+type decode_error =
+  [ `Fatal of Tar.error | `Unexpected_end_of_file | `Msg of string ]
+
+let ( / ) = Eio.Path.( / )
+let ( let* ) = Result.bind
+let ( let+ ) v f = Result.map f v
 
 module High : sig
   type t
@@ -36,51 +41,36 @@ type t = High.t
 
 let value v = Tar.High (High.inj v)
 
-let run_read_only t f =
+let run t f =
   let rec run : type a. (a, 'err, t) Tar.t -> (a, 'err) result = function
     | Tar.Write _ -> assert false
-    | Tar.Read len ->
-      let b = Cstruct.create len in
-      (match Flow.single_read f b with
-       | len ->
-         Ok (Cstruct.to_string ~len b)
-       | exception End_of_file ->
-         (* XXX: should we catch other exceptions?! *)
-         Error `Unexpected_end_of_file)
-    | Tar.Really_read len ->
-      let b = Cstruct.create len in
-      (try
-         Flow.read_exact f b;
-         Ok (Cstruct.to_string b)
-       with End_of_file -> Error `Unexpected_end_of_file)
+    | Tar.Read len -> (
+        let b = Cstruct.create len in
+        match Eio.Flow.single_read f b with
+        | len -> Ok (Cstruct.to_string ~len b)
+        | exception End_of_file ->
+            (* XXX: should we catch other exceptions?! *)
+            Error `Unexpected_end_of_file)
+    | Tar.Really_read len -> (
+        let b = Cstruct.create len in
+        try
+          Eio.Flow.read_exact f b;
+          Ok (Cstruct.to_string b)
+        with End_of_file -> Error `Unexpected_end_of_file)
     | Tar.Seek n ->
-      let buffer_size = 32768 in
-      let buffer = Cstruct.create buffer_size in
-      let rec loop (n: int) =
-        if n <= 0 then Ok ()
-        else
-          let amount = min n buffer_size in
-          let block = Cstruct.sub buffer 0 amount in
-          Flow.read_exact f block;
-          loop (n - amount) in
-      loop n
+        let _set : Optint.Int63.t =
+          Eio.File.seek f (Optint.Int63.of_int n) `Set
+        in
+        Ok ()
     | Tar.Return value -> value
     | Tar.High value -> High.prj value
-    | Tar.Bind (x, f) ->
-      match run x with
-      | Ok value -> run (f value)
-      | Error _ as err -> err in
+    | Tar.Bind (x, f) -> (
+        match run x with Ok value -> run (f value) | Error _ as err -> err)
+  in
   run t
 
-let fold f filename init =
-  (* XXX(reynir): ??? *)
-  Eio.Path.with_open_in filename
-    (run_read_only (Tar.fold f init))
-
-(* Eio needs a non-file-opening stat. *)
-let stat path =
-  Eio.Path.with_open_in path @@ fun f ->
-  Eio.File.stat f
+let fold f source init = run (Tar.fold f init) source
+let stat path = Eio.Path.stat ~follow:true path
 
 (** Return the header needed for a particular file on disk *)
 let header_of_file ?level ?getpwuid ?getgrgid filepath : Tar.Header.t =
@@ -88,41 +78,110 @@ let header_of_file ?level ?getpwuid ?getgrgid filepath : Tar.Header.t =
   let stat = stat filepath in
   let pwent = Option.map (fun f -> f stat.uid) getpwuid in
   let grent = Option.map (fun f -> f stat.gid) getgrgid in
-  let uname       = if level = V7 then Some "" else pwent in
-  let gname       = if level = V7 then Some "" else grent in
-  let file_mode   = stat.perm in
-  let user_id     = stat.uid |> Int64.to_int in
-  let group_id    = stat.gid |> Int64.to_int in
-  let file_size   = stat.size |> Optint.Int63.to_int64 in
-  let mod_time    = Int64.of_float stat.mtime in
+  let uname = if level = V7 then Some "" else pwent in
+  let gname = if level = V7 then Some "" else grent in
+  let file_mode = stat.perm in
+  let user_id = stat.uid |> Int64.to_int in
+  let group_id = stat.gid |> Int64.to_int in
+  let file_size = stat.size |> Optint.Int63.to_int64 in
+  let mod_time = Int64.of_float stat.mtime in
   let link_indicator = Tar.Header.Link.Normal in
-  let link_name   = "" in
-  let devmajor    = if level = Ustar then stat.dev |> Int64.to_int else 0 in
-  let devminor    = if level = Ustar then stat.rdev |> Int64.to_int else 0 in
-  Tar.Header.make ~file_mode ~user_id ~group_id ~mod_time ~link_indicator ~link_name
-                  ?uname ?gname ~devmajor ~devminor (snd filepath) file_size
-let extract ?filter:(_ = fun _ -> true) ~src:_ _dst =
-  (* TODO *)
-  failwith "TODO"
+  let link_name = "" in
+  let devmajor = if level = Ustar then stat.dev |> Int64.to_int else 0 in
+  let devminor = if level = Ustar then stat.rdev |> Int64.to_int else 0 in
+  Tar.Header.make ~file_mode ~user_id ~group_id ~mod_time ~link_indicator
+    ~link_name ?uname ?gname ~devmajor ~devminor (snd filepath) file_size
 
-let create ?level:_ ?global:_ ?filter:(_ = fun _ -> true) ~src:_ _dst =
-  (* TODO *)
-  failwith "TODO"
+let copy dst len =
+  let blen = 65536 in
+  let rec read_write dst len =
+    if len = 0 then value (Ok ())
+    else
+      let ( let* ) = Tar.( let* ) in
+      let slen = min blen len in
+      let* str = Tar.really_read slen in
+      let* _written = Result.ok (Eio.Flow.copy_string str dst) |> value in
+      read_write dst (len - slen)
+  in
+  read_write dst len
 
-let append_file ?level:_ ?header:_ _filename _dst =
-  (* TODO *)
-  failwith "TODO"
+let extract ?(filter = fun _ -> true) src dst =
+  let f ?global:_ hdr () =
+    let ( let* ) = Tar.( let* ) in
+    match (filter hdr, hdr.Tar.Header.link_indicator) with
+    | true, Tar.Header.Link.Normal ->
+        Eio.Path.with_open_out ~create:(`If_missing hdr.Tar.Header.file_mode)
+          (dst / hdr.file_name)
+        @@ fun dst -> copy dst (Int64.to_int hdr.Tar.Header.file_size)
+    | _ ->
+        let* () = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
+        Tar.return (Ok ())
+  in
+  fold f src ()
 
-let write_header ?level:_ _hdr _fl =
-  (* TODO *)
-  failwith "TODO"
+let write_strings fd datas =
+  List.iter (fun d -> Eio.Flow.copy_string d fd) datas
 
-let write_global_extended_header ?level:_ _global _fl =
-  (* TODO *)
-  failwith "TODO"
+let write_header ?level hdr fl =
+  let+ bytes = Tar.encode_header ?level hdr in
+  write_strings fl bytes
+
+let copy src sink len =
+  let blen = 65536 in
+  let buf = Cstruct.create blen in
+  let rec read_and_write len =
+    if len = 0 then Ok ()
+    else
+      match Eio.Flow.single_read src buf with
+      | n ->
+          Eio.Flow.write sink [ Cstruct.sub buf 0 n ];
+          read_and_write (len - n)
+      | exception End_of_file -> Error (`Msg "Unexpected end of file")
+  in
+  read_and_write len
+
+let append_file ?level ?header filename dst =
+  let header =
+    match header with None -> header_of_file ?level filename | Some x -> x
+  in
+  let* () = write_header ?level header dst in
+  Eio.Path.with_open_in filename @@ fun src ->
+  (* TOCTOU [also, header may not be valid for file] *)
+  copy src dst (Int64.to_int header.Tar.Header.file_size)
+
+let write_global_extended_header ?level header sink =
+  Result.map (write_strings sink)
+    (Tar.encode_global_extended_header ?level header)
 
 let write_end fl =
-  let zero_block = Cstruct.of_string Tar.Header.zero_block in
-  (* TODO: catch exceptions?! *)
-  Eio.Flow.write fl [ zero_block; zero_block ];
-  Ok ()
+  write_strings fl [ Tar.Header.zero_block; Tar.Header.zero_block ]
+
+let create ?level ?global ?(filter = fun _ -> true) ~src dst =
+  match global with
+  | None -> Ok ()
+  | Some hdr ->
+      let* () = write_global_extended_header ?level hdr dst in
+      let rec copy_files directory =
+        let rec next = function
+          | [] -> Ok ()
+          | name :: names -> (
+              try
+                let filename = directory / name in
+                let header = header_of_file ?level filename in
+                if filter header then
+                  match header.Tar.Header.link_indicator with
+                  | Normal ->
+                      let* () = append_file ?level ~header filename dst in
+                      next names
+                  | Directory ->
+                      (* TODO first finish curdir (and close the dir fd), then go deeper *)
+                      let* () = copy_files filename in
+                      next names
+                  | _ -> Ok () (* NYI *)
+                else Ok ()
+              with End_of_file -> Ok ())
+        in
+        next (Eio.Path.read_dir directory)
+      in
+      let+ () = copy_files src in
+      write_end dst

--- a/eio/tar_eio.mli
+++ b/eio/tar_eio.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(** {0 Eio Tar} 
+(** {1 Eio Tar} 
 
     This library provides low-level and high-level abstractions for reading
     and writing Tar files using Eio.
@@ -24,20 +24,17 @@ type t
 
 type src =
   | Flow : _ Eio.Flow.source -> src
-  | File : _ Eio.File.ro -> src
-(** Sources for tar files *)
+  | File : _ Eio.File.ro -> src  (** Sources for tar files *)
 
 type decode_error =
   [ `Fatal of Tar.error | `Unexpected_end_of_file | `Msg of string ]
 (** Possible decoding errors *)
 
-(** {1 High-level Interface} *)
+(** {2 High-level Interface} *)
 
 val run :
-  ('a, ([> `Unexpected_end_of_file ] as 'b), t) Tar.t ->
-  src ->
-  ('a, 'b) result
-  (** [run tar src] will run the given [tar] using {! Eio} on [src]. *)
+  ('a, ([> `Unexpected_end_of_file ] as 'b), t) Tar.t -> src -> ('a, 'b) result
+(** [run tar src] will run the given [tar] using {! Eio} on [src]. *)
 
 val extract :
   ?filter:(Tar.Header.t -> bool) ->
@@ -51,7 +48,9 @@ val extract :
       Tar_eio.extract src dst
     ]}
 
-    will extract the file at [src] into the directory at [dst].
+    will extract the file at [src] into the directory at [dst]. Note that this function
+    only creates {b files}, {b directories} and {b symlinks} with the correct mode (it does not, for
+    example, set the ownership of the files according to the tar file).
 
     @param filter Can be used to exclude certain entries based on their header. *)
 
@@ -78,7 +77,7 @@ val fold :
   ('acc, 'b) result
 (** [fold f src init] folds over the tarred [src]. *)
 
-(** {1 Low-level Interface} *)
+(** {2 Low-level Interface} *)
 
 val value : ('a, 'err) result -> ('a, 'err, t) Tar.t
 (** Converts a normal result into {! Tar}s IO type *)

--- a/eio/tar_eio.mli
+++ b/eio/tar_eio.mli
@@ -22,6 +22,11 @@
 
 type t
 
+type src =
+  | Flow : _ Eio.Flow.source -> src
+  | File : _ Eio.File.ro -> src
+(** Sources for tar files *)
+
 type decode_error =
   [ `Fatal of Tar.error | `Unexpected_end_of_file | `Msg of string ]
 (** Possible decoding errors *)
@@ -30,13 +35,13 @@ type decode_error =
 
 val run :
   ('a, ([> `Unexpected_end_of_file ] as 'b), t) Tar.t ->
-  _ Eio.File.ro ->
+  src ->
   ('a, 'b) result
   (** [run tar src] will run the given [tar] using {! Eio} on [src]. *)
 
 val extract :
   ?filter:(Tar.Header.t -> bool) ->
-  _ Eio.File.ro ->
+  src ->
   Eio.Fs.dir_ty Eio.Path.t ->
   (unit, [> decode_error ]) result
 (** [extract src dst] extracts the tar file from [src] into [dst]. For example:
@@ -68,7 +73,7 @@ val fold :
   Tar.Header.t ->
   'acc ->
   ('acc, ([> `Fatal of Tar.error | `Unexpected_end_of_file ] as 'b), t) Tar.t) ->
-  _ Eio.File.ro ->
+  src ->
   'acc ->
   ('acc, 'b) result
 (** [fold f src init] folds over the tarred [src]. *)

--- a/eio/tar_eio.mli
+++ b/eio/tar_eio.mli
@@ -14,57 +14,98 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(** I/O for tar-formatted data *)
+(** {0 Eio Tar} 
+
+    This library provides low-level and high-level abstractions for reading
+    and writing Tar files using Eio.
+*)
 
 type t
 
-val value : ('a, 'err) result -> ('a, 'err, t) Tar.t
+type decode_error =
+  [ `Fatal of Tar.error | `Unexpected_end_of_file | `Msg of string ]
+(** Possible decoding errors *)
 
-val run_read_only : ('a, [> `Unexpected_end_of_file] as 'b, t) Tar.t -> [> `R ] Eio.Flow.source -> ('a, 'b) result
+(** {1 High-level Interface} *)
 
-val fold :
-  (?global:Tar.Header.Extended.t ->
-   Tar.Header.t ->
-   'a ->
-   ('a, [> `Fatal of Tar.error | `Unexpected_end_of_file ] as 'b, t) Tar.t) ->
-  Eio.Fs.dir_ty Eio.Path.t ->
-  'a ->
+val run :
+  ('a, ([> `Unexpected_end_of_file ] as 'b), t) Tar.t ->
+  _ Eio.File.ro ->
   ('a, 'b) result
+  (** [run tar src] will run the given [tar] using {! Eio} on [src]. *)
 
-(** Return the header needed for a particular file on disk. [getpwuid] and [getgrgid] are optional
-    functions that should take the uid and gid respectively and return the passwd and group entry
-    names for each. These will be added to the header. *)
-val header_of_file :
-    ?level:Tar.Header.compatibility ->
-    ?getpwuid:(int64 -> string) ->
-    ?getgrgid:(int64 -> string) ->
-    Eio.Fs.dir_ty Eio.Path.t ->
-    Tar.Header.t
-
-val extract : ?filter:(Tar.Header.t -> bool) ->
-  src:Eio.Fs.dir_ty Eio.Path.t ->
+val extract :
+  ?filter:(Tar.Header.t -> bool) ->
+  _ Eio.File.ro ->
   Eio.Fs.dir_ty Eio.Path.t ->
-  (unit, _) result
+  (unit, [> decode_error ]) result
+(** [extract src dst] extracts the tar file from [src] into [dst]. For example:
 
-val create : ?level:Tar.Header.compatibility ->
+    {[
+      Eio.Path.with_open_in src @@ fun src ->
+      Tar_eio.extract src dst
+    ]}
+
+    will extract the file at [src] into the directory at [dst].
+
+    @param filter Can be used to exclude certain entries based on their header. *)
+
+val create :
+  ?level:Tar.Header.compatibility ->
   ?global:Tar.Header.Extended.t ->
   ?filter:(Tar.Header.t -> bool) ->
   src:Eio.Fs.dir_ty Eio.Path.t ->
-  Eio.Fs.dir_ty Eio.Path.t ->
-  (unit, _) result
+  _ Eio.Flow.sink ->
+  (unit, [> decode_error ]) result
+(** [create ~src dst] is the opposite of {! extract}. The path [src] is tarred
+    into [dst].
 
-val append_file : ?level:Tar.Header.compatibility ->
+    @param filter Can be used to exclude certain entries based on their header.
+*)
+
+val fold :
+  (?global:Tar.Header.Extended.t ->
+  Tar.Header.t ->
+  'acc ->
+  ('acc, ([> `Fatal of Tar.error | `Unexpected_end_of_file ] as 'b), t) Tar.t) ->
+  _ Eio.File.ro ->
+  'acc ->
+  ('acc, 'b) result
+(** [fold f src init] folds over the tarred [src]. *)
+
+(** {1 Low-level Interface} *)
+
+val value : ('a, 'err) result -> ('a, 'err, t) Tar.t
+(** Converts a normal result into {! Tar}s IO type *)
+
+val append_file :
+  ?level:Tar.Header.compatibility ->
   ?header:Tar.Header.t ->
   Eio.Fs.dir_ty Eio.Path.t ->
-  [> `W ] Eio.Flow.sink ->
-  (unit, _) result
+  _ Eio.Flow.sink ->
+  (unit, [> decode_error ]) result
+(** [append_file dst sink] *)
 
-val write_header : ?level:Tar.Header.compatibility ->
-  Tar.Header.t -> [> `W ] Eio.Flow.sink ->
-  (unit, _) result
+val header_of_file :
+  ?level:Tar.Header.compatibility ->
+  ?getpwuid:(int64 -> string) ->
+  ?getgrgid:(int64 -> string) ->
+  Eio.Fs.dir_ty Eio.Path.t ->
+  Tar.Header.t
+(** Return the header needed for a particular file on disk. [getpwuid] and [getgrgid] are optional
+    functions that should take the uid and gid respectively and return the passwd and group entry
+    names for each. These will be added to the header. *)
 
-val write_global_extended_header : ?level:Tar.Header.compatibility ->
-  Tar.Header.Extended.t -> [> `W ] Eio.Flow.sink ->
-  (unit, _) result
+val write_header :
+  ?level:Tar.Header.compatibility ->
+  Tar.Header.t ->
+  _ Eio.Flow.sink ->
+  (unit, [> decode_error ]) result
 
-val write_end : [> `W ] Eio.Flow.sink -> (unit, _) result
+val write_global_extended_header :
+  ?level:Tar.Header.compatibility ->
+  Tar.Header.Extended.t ->
+  _ Eio.Flow.sink ->
+  (unit, [> decode_error ]) result
+
+val write_end : _ Eio.Flow.sink -> unit

--- a/tar-eio.opam
+++ b/tar-eio.opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "5.00.0"}
-  "eio" {>= "1.1" & < "1.2"}
+  "eio" {>= "1.1"}
   "tar" {= version}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Implements missing functionality in Tar_eio and also tidies up the interfaces to the library itself.

Most of this is borrowed from `lwt` version of the library and ported to Eio primitives. The Eio portion of the library is not tested anywhere which I'm looking into.