### PR TITLE
Move Tar.( let* ) to a new Tar.Syntax submodule and add Tar.bind

### DIFF
--- a/bin/otar.ml
+++ b/bin/otar.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Tar.Syntax
+
 let () = Printexc.record_backtrace true
 
 let ( / ) = Filename.concat
@@ -99,9 +101,8 @@ let list filename =
       hdr.Tar.Header.file_name
       (Tar.Header.Link.to_string hdr.link_indicator)
       (bytes_to_size ~decimals:2) hdr.Tar.Header.file_size ;
-    let open Tar in
-    let* _ = seek (Int64.to_int hdr.Tar.Header.file_size) in
-    return (Ok ())
+    let* () = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
+    Tar.return (Ok ())
   in
   let fd = Unix.openfile filename [ Unix.O_RDONLY ] 0 in
   match Tar_unix.run (Tar_gz.in_gzipped (Tar.fold go ())) fd with

--- a/eio/tar_eio.ml
+++ b/eio/tar_eio.ml
@@ -122,7 +122,7 @@ let copy dst len =
   let rec read_write dst len =
     if len = 0 then value (Ok ())
     else
-      let ( let* ) = Tar.( let* ) in
+      let open Tar.Syntax in
       let slen = min blen len in
       let* str = Tar.really_read slen in
       let* _written = Result.ok (Eio.Flow.copy_string str dst) |> value in
@@ -132,7 +132,7 @@ let copy dst len =
 
 let extract ?(filter = fun _ -> true) src dst =
   let f ?global:_ hdr () =
-    let ( let* ) = Tar.( let* ) in
+    let open Tar.Syntax in
     let path = dst / hdr.Tar.Header.file_name in
     match (filter hdr, hdr.Tar.Header.link_indicator) with
     | true, Tar.Header.Link.Normal ->

--- a/lib/tar.ml
+++ b/lib/tar.ml
@@ -832,12 +832,18 @@ type ('a, 'err, 't) t =
   | High : (('a, 'err) result, 't) io -> ('a, 'err, 't) t
   | Write : string -> (unit, 'err, 't) t
 
-let ( let* ) x f = Bind (x, f)
+let bind x f = Bind (x, f)
 let return x = Return x
 let really_read n = Really_read n
 let read n = Read n
 let seek n = Seek n
 let write str = Write str
+
+module Syntax = struct
+  let ( let* ) = bind
+end
+
+open Syntax
 
 type ('a, 'err, 't) fold = (?global:Header.Extended.t -> Header.t -> 'a -> ('a, 'err, 't) t) -> 'a -> ('a, 'err, 't) t
 

--- a/lib/tar.mli
+++ b/lib/tar.mli
@@ -201,9 +201,13 @@ type ('a, 'err, 't) t =
 val really_read : int -> (string, _, _) t
 val read : int -> (string, _, _) t
 val seek : int -> (unit, _, _) t
-val ( let* ) : ('a, 'err, 't) t -> ('a -> ('b, 'err, 't) t) -> ('b, 'err, 't) t
+val bind : ('a, 'err, 't) t -> ('a -> ('b, 'err, 't) t) -> ('b, 'err, 't) t
 val return : ('a, 'err) result -> ('a, 'err, _) t
 val write : string -> (unit, _, _) t
+
+module Syntax : sig
+  val ( let* ) : ('a, 'err, 't) t -> ('a -> ('b, 'err, 't) t) -> ('b, 'err, 't) t
+end
 
 type ('a, 'err, 't) fold = (?global:Header.Extended.t -> Header.t -> 'a -> ('a, 'err, 't) t) -> 'a -> ('a, 'err, 't) t
 

--- a/lib_test/global_extended_headers_test.ml
+++ b/lib_test/global_extended_headers_test.ml
@@ -47,7 +47,7 @@ let use_global_extended_headers _test_ctxt =
       Alcotest.testable (fun ppf hdr -> Fmt.pf ppf "%a" Fmt.(option pp) hdr) ( = )
     in
     let f ?global hdr idx =
-      let ( let* ) = Tar.( let* ) in
+      let open Tar.Syntax in
       let* _pos = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
       match idx with
       | 0 ->

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -13,6 +13,7 @@
  *)
 
 open Lwt.Infix
+open Tar.Syntax
 
 let convert_path os path =
   let ch = Unix.open_process_in (Printf.sprintf "cygpath -%c -- %s" (match os with `Mixed -> 'm' | `Unix -> 'u' | `Windows -> 'w') path) in
@@ -34,8 +35,7 @@ end
 let list filename =
   let f ?global:_ hdr acc =
     print_endline hdr.Tar.Header.file_name;
-    let ( let* ) = Tar.( let* ) in
-    let* _pos = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
+    let* () = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
     Tar.return (Ok (hdr :: acc))
   in
   match Tar_unix.fold f filename [] with
@@ -169,8 +169,7 @@ let can_list_pax_implicit_dir () =
   let f ?global:_ hdr () =
     Alcotest.(check link) "is directory" Tar.Header.Link.Directory hdr.Tar.Header.link_indicator;
     Alcotest.(check string) "filename is patched" "clearly/a/directory/" hdr.file_name;
-    let ( let* ) = Tar.( let* ) in
-    let* _pos = Tar.seek (Int64.to_int hdr.file_size) in
+    let* () = Tar.seek (Int64.to_int hdr.file_size) in
     Tar.return (Ok ())
   in
   match Tar_unix.fold f "lib_test/pax-shenanigans.tar" () with
@@ -192,8 +191,7 @@ let can_list_longlink_implicit_dir () =
   let f ?global:_ hdr () =
     Alcotest.(check link) "is directory" Tar.Header.Link.Directory hdr.Tar.Header.link_indicator;
     Alcotest.(check string) "filename is patched" "some/long/name/for/a/directory/" hdr.file_name;
-    let ( let* ) = Tar.( let* ) in
-    let* _pos = Tar.seek (Int64.to_int hdr.file_size) in
+    let* () = Tar.seek (Int64.to_int hdr.file_size) in
     Tar.return (Ok ())
   in
   match Tar_unix.fold f "lib_test/long-implicit-dir.tar" () with
@@ -216,8 +214,7 @@ let can_transform_tar () =
   let fd_out = Unix.openfile tar_out [ O_WRONLY; O_CREAT; O_CLOEXEC ] 0o644 in
   with_tmpdir @@ fun temp_dir ->
   let f ?global:_ hdr _ =
-    let ( let* ) = Tar.( let* ) in
-    let* _pos = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
+    let* () = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
     let hdr =
       { hdr with
         Tar.Header.file_name = Filename.concat temp_dir hdr.file_name;
@@ -236,8 +233,7 @@ let can_transform_tar () =
     | Ok () ->
       Unix.close fd_out;
       let f ?global:_ hdr _ =
-        let ( let* ) = Tar.( let* ) in
-        let* _pos = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
+        let* () = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
         Alcotest.(check string) "Filename was transformed" temp_dir
           (String.sub hdr.file_name 0 (min (String.length hdr.file_name) (String.length temp_dir)));
         Tar.return (Ok ())

--- a/unix/tar_lwt_unix.ml
+++ b/unix/tar_lwt_unix.ml
@@ -15,6 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Tar.Syntax
+
 type decode_error = [
   | `Fatal of Tar.error
   | `Unix of Unix.error * string * string
@@ -122,7 +124,6 @@ let copy ~dst_fd len =
   let rec read_write ~dst_fd len =
     if len = 0 then value (Lwt.return (Ok ()))
     else
-      let ( let* ) = Tar.( let* ) in
       let slen = min blen len in
       let* str = Tar.really_read slen in
       let* _written = Lwt_result.map_error unix_err_to_msg
@@ -139,7 +140,6 @@ let extract ?(filter = fun _ -> true) ~src dst =
       (fun _ -> Lwt.return_unit)
     >|= Result.ok in
   let f ?global:_ hdr () =
-    let ( let* ) = Tar.( let* ) in
     match filter hdr, hdr.Tar.Header.link_indicator with
     | true, Tar.Header.Link.Normal ->
       let* dst = Lwt_result.map_error

--- a/unix/tar_unix.ml
+++ b/unix/tar_unix.ml
@@ -127,7 +127,7 @@ let unix_err_to_msg = function
 let copy ~dst_fd len =
   let blen = 65536 in
   let rec read_write ~dst_fd len =
-    let ( let* ) = Tar.( let* ) in
+    let open Tar.Syntax in
     if len = 0 then Tar.return (Ok ())
     else
       let slen = min blen len in
@@ -156,11 +156,11 @@ let extract ?(filter = fun _ -> true) ~src dst =
         (* TODO set owner / mode / mtime etc. *)
       | _ ->
         (* TODO handle directories, links, etc. *)
-        let ( let* ) = Tar.( let* ) in
+        let open Tar.Syntax in
         let* () = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
         Tar.return (Ok ())
     else
-      let ( let* ) = Tar.( let* ) in
+      let open Tar.Syntax in
       let* () = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
       Tar.return (Ok ())
   in


### PR DESCRIPTION
Encouraging the use of `open Tar` is bad design in my opinion. Thus this PR proposes to move the only let-operator from the toplevel module to a new `Syntax` submodule per community consensus (c.f. `lwt`, https://github.com/ocaml/ocaml/pull/2170 and many more)