### PR TITLE
Make eio API more polymorphic

### DIFF
--- a/eio/tar_eio.mli
+++ b/eio/tar_eio.mli
@@ -39,7 +39,7 @@ val run :
 val extract :
   ?filter:(Tar.Header.t -> bool) ->
   src ->
-  Eio.Fs.dir_ty Eio.Path.t ->
+  _ Eio.Path.t ->
   (unit, [> decode_error ]) result
 (** [extract src dst] extracts the tar file from [src] into [dst]. For example:
 
@@ -58,7 +58,7 @@ val create :
   ?level:Tar.Header.compatibility ->
   ?global:Tar.Header.Extended.t ->
   ?filter:(Tar.Header.t -> bool) ->
-  src:Eio.Fs.dir_ty Eio.Path.t ->
+  src:_ Eio.Path.t ->
   _ Eio.Flow.sink ->
   (unit, [> decode_error ]) result
 (** [create ~src dst] is the opposite of {! extract}. The path [src] is tarred
@@ -85,7 +85,7 @@ val value : ('a, 'err) result -> ('a, 'err, t) Tar.t
 val append_file :
   ?level:Tar.Header.compatibility ->
   ?header:Tar.Header.t ->
-  Eio.Fs.dir_ty Eio.Path.t ->
+  _ Eio.Path.t ->
   _ Eio.Flow.sink ->
   (unit, [> decode_error ]) result
 (** [append_file dst sink] *)
@@ -94,7 +94,7 @@ val header_of_file :
   ?level:Tar.Header.compatibility ->
   ?getpwuid:(int64 -> string) ->
   ?getgrgid:(int64 -> string) ->
-  Eio.Fs.dir_ty Eio.Path.t ->
+  _ Eio.Path.t ->
   Tar.Header.t
 (** Return the header needed for a particular file on disk. [getpwuid] and [getgrgid] are optional
     functions that should take the uid and gid respectively and return the passwd and group entry


### PR DESCRIPTION
This allows Eio paths that offer _at least_ the directory signature to be used with the Tar API. Previously _only exactly_ filesystem paths could be used. For more information see: https://ocaml-multicore.github.io/eio/eio/Eio/Resource/index.html

As a very contrived example, the following typechecks with this PR but in the current API it will not.

```ocaml
type extra_ty = [ Eio.Fs.dir_ty | `Extra ]

let () =
  Eio_main.run @@ fun env ->
  let path : extra_ty Eio.Path.t = Obj.magic @@ Eio.Path.(env#cwd / "foo") in
  Eio.Path.(with_open_out ~create:(`If_missing 0o644) (env#cwd / "foo.tar")) @@ fun out ->
  Tar_eio.create ~src:path out |> Result.get_ok
```

