### PR TITLE
Update `Tar_eio`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -90,5 +90,8 @@
   (ocaml (>= 5.00.0))
   (eio (and (>= 1.1)))
   (tar (= :version))
+  (eio_main :with-test)
+  (alcotest :with-test)
+  (decompress :with-test)
  )
 )

--- a/eio/tar_eio.ml
+++ b/eio/tar_eio.ml
@@ -154,8 +154,7 @@ let rec symlink_p ~link_to path =
     Eio.Path.unlink path;
     symlink_p ~link_to path
 
-let extract ?(filter = fun _ -> true) dst fn =
-  Eio.Switch.run @@ fun sw ->
+let extract ?(filter = fun _ -> true) ~sw dst =
   let f ?global:_ hdr () =
     let open Tar.Syntax in
     let path = dst / hdr.Tar.Header.file_name in
@@ -178,7 +177,7 @@ let extract ?(filter = fun _ -> true) dst fn =
         let* () = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
         Tar.return (Ok ())
   in
-  fn @@ Tar.fold f ()
+  Tar.fold f ()
 
 let write_strings fd datas =
   List.iter (fun d -> Eio.Flow.copy_string d fd) datas
@@ -218,7 +217,7 @@ let write_end fl =
   write_strings fl [ Tar.Header.zero_block; Tar.Header.zero_block ]
 
 let tar_header_of_file (stat : Eio.File.Stat.t) path =
-  let file_mode = if stat.perm land 0o111 <> 0 then 0o755 else 0o644 in
+  let file_mode = stat.perm in
   let mod_time = Int64.of_float stat.mtime in
   let user_id = Int64.to_int stat.uid in
   let group_id = Int64.to_int stat.gid in
@@ -249,7 +248,7 @@ let tar_header_of_file (stat : Eio.File.Stat.t) path =
   Tar.Header.make ~file_mode ?link_name ~mod_time ~user_id ~group_id
     ~link_indicator path size
 
-let create ?level ?global ?(filter = fun _ -> true) src fn =
+let create ?level ?global ?(filter = fun _ -> true) ~sw src =
   let contents_of_path ~sw path =
     let fd = ref `None in
     let buf = Cstruct.create 0x100 in
@@ -315,7 +314,6 @@ let create ?level ?global ?(filter = fun _ -> true) src fn =
     in
     loop [] ((List.map Eio.Path.(( / ) src)) files)
   in
-  Eio.Switch.run @@ fun sw ->
   let entries = to_stream (dir_entry :: entries sw) in
   let entries () = Tar.return (Ok (entries ())) in
-  fn @@ Tar.out ?level ?global_hdr:global entries
+  Tar.out ?level ?global_hdr:global entries

--- a/eio/tar_eio.ml
+++ b/eio/tar_eio.ml
@@ -139,31 +139,46 @@ let copy dst len =
       let open Tar.Syntax in
       let slen = min blen len in
       let* str = Tar.really_read slen in
-      let* _written = Result.ok (Eio.Flow.copy_string str dst) |> value in
+      let* () = Result.ok (Eio.Flow.copy_string str dst) |> value in
       read_write dst (len - slen)
   in
   read_write dst len
 
-let extract ?(filter = fun _ -> true) src dst =
+let mkdir_p ~perm path =
+  try Eio.Path.mkdir ~perm path
+  with Eio.Io (Eio.Fs.E (Already_exists _), _) -> ()
+
+let rec symlink_p ~link_to path =
+  try Eio.Path.symlink ~link_to path
+  with Eio.Io (Eio.Fs.E (Already_exists _), _) ->
+    Eio.Path.unlink path;
+    symlink_p ~link_to path
+
+let extract ?(filter = fun _ -> true) dst fn =
+  Eio.Switch.run @@ fun sw ->
   let f ?global:_ hdr () =
     let open Tar.Syntax in
     let path = dst / hdr.Tar.Header.file_name in
     match (filter hdr, hdr.Tar.Header.link_indicator) with
     | true, Tar.Header.Link.Normal ->
-        Eio.Path.with_open_out ~create:(`If_missing hdr.Tar.Header.file_mode)
-          path
-        @@ fun dst -> copy dst (Int64.to_int hdr.Tar.Header.file_size)
+        let dst =
+          Eio.Path.open_out ~sw ~create:(`Or_truncate hdr.Tar.Header.file_mode)
+            path
+        in
+        let* () = copy dst (Int64.to_int hdr.Tar.Header.file_size) in
+        let* () = Tar.return (Ok (Eio.Flow.close dst)) in
+        Tar.return (Ok ())
     | true, Tar.Header.Link.Symbolic ->
-        Eio.Path.symlink ~link_to:hdr.link_name path;
+        symlink_p ~link_to:hdr.link_name path;
         Tar.return (Ok ())
     | true, Tar.Header.Link.Directory ->
-        Eio.Path.mkdir ~perm:hdr.file_mode path;
+        mkdir_p ~perm:hdr.file_mode path;
         Tar.return (Ok ())
     | _ ->
         let* () = Tar.seek (Int64.to_int hdr.Tar.Header.file_size) in
         Tar.return (Ok ())
   in
-  fold f src ()
+  fn @@ Tar.fold f ()
 
 let write_strings fd datas =
   List.iter (fun d -> Eio.Flow.copy_string d fd) datas
@@ -202,33 +217,105 @@ let write_global_extended_header ?level header sink =
 let write_end fl =
   write_strings fl [ Tar.Header.zero_block; Tar.Header.zero_block ]
 
-let create ?level ?global ?(filter = fun _ -> true) ~src dst =
-  let* () =
-    match global with
-    | None -> Ok ()
-    | Some hdr -> write_global_extended_header ?level hdr dst
+let tar_header_of_file (stat : Eio.File.Stat.t) path =
+  let file_mode = if stat.perm land 0o111 <> 0 then 0o755 else 0o644 in
+  let mod_time = Int64.of_float stat.mtime in
+  let user_id = Int64.to_int stat.uid in
+  let group_id = Int64.to_int stat.gid in
+  let link_indicator =
+    match stat.kind with
+    | `Regular_file -> Tar.Header.Link.Normal
+    | `Directory -> Directory
+    | `Block_device -> Block
+    | `Character_special -> Character
+    | `Fifo -> FIFO
+    | `Symbolic_link -> Symbolic
+    | `Socket | `Unknown ->
+        failwith "Cannot create a tar header for sockets or unknown file kinds"
   in
-  let rec copy_files directory =
-    let rec next = function
-      | [] -> Ok ()
-      | name :: names -> (
-          try
-            let filename = directory / name in
-            let header = header_of_file ?level filename in
-            if filter header then
-              match header.Tar.Header.link_indicator with
-              | Normal ->
-                  let* () = append_file ?level ~header filename dst in
-                  next names
-              | Directory ->
-                  (* TODO first finish curdir (and close the dir fd), then go deeper *)
-                  let* () = copy_files filename in
-                  next names
-              | _ -> Ok () (* NYI *)
-            else Ok ()
-          with End_of_file -> Ok ())
+  (* Only files have a size *)
+  let link_name, size =
+    match link_indicator with
+    | Symbolic -> (Some (Eio.Path.read_link path), 0L)
+    | Normal -> (None, Optint.Int63.to_int64 stat.size)
+    | _ -> (None, 0L)
+  in
+  (* Add a trailing slash *)
+  let path =
+    match link_indicator with
+    | Directory -> Eio.Path.(path / "") |> Eio.Path.native_exn
+    | _ -> Eio.Path.native_exn path
+  in
+  Tar.Header.make ~file_mode ?link_name ~mod_time ~user_id ~group_id
+    ~link_indicator path size
+
+let create ?level ?global ?(filter = fun _ -> true) src fn =
+  let contents_of_path ~sw path =
+    let fd = ref `None in
+    let buf = Cstruct.create 0x100 in
+    let rec dispenser () =
+      match !fd with
+      | `Closed -> Tar.return (Ok None)
+      | `None ->
+          let fd' = Eio.Path.open_in ~sw path in
+          fd := `Active fd';
+          dispenser ()
+      | `Active fd' -> (
+          match Eio.Flow.single_read fd' buf with
+          | 0 | (exception End_of_file) ->
+              Eio.Flow.close fd';
+              fd := `Closed;
+              Tar.return (Ok None)
+          | len ->
+              let str = Cstruct.to_string ~off:0 ~len buf in
+              Tar.return (Ok (Some str)))
     in
-    next (Eio.Path.read_dir directory)
+    dispenser
   in
-  let+ () = copy_files src in
-  write_end dst
+  let to_stream lst =
+    let lst = ref lst in
+    fun () ->
+      match !lst with
+      | [] -> None
+      | x :: r ->
+          lst := r;
+          Some x
+  in
+  let files = Eio.Path.read_dir src in
+  let dir_hdr = tar_header_of_file (Eio.Path.stat ~follow:false src) src in
+  let dir_entry = (None, dir_hdr, fun () -> Tar.return (Ok None)) in
+  let entries sw =
+    let rec loop acc = function
+      | [] -> List.rev acc
+      | file_path :: rest -> (
+          let stat = Eio.Path.stat ~follow:false file_path in
+          let hdr = tar_header_of_file stat file_path in
+          let skip v = if not (filter hdr) then loop acc rest else v in
+          match stat.kind with
+          | `Regular_file ->
+              skip
+              @@ loop ((level, hdr, contents_of_path ~sw file_path) :: acc) rest
+          | `Directory ->
+              skip
+              @@
+              let new_files =
+                Eio.Path.read_dir file_path
+                |> List.map Eio.Path.(( / ) file_path)
+              in
+              loop
+                ((level, hdr, fun () -> Tar.return (Ok None)) :: acc)
+                (new_files @ rest)
+          | `Unknown | `Socket ->
+              (* Skipping files without a Tar header format. *)
+              loop acc rest
+          | _ ->
+              skip
+              @@ loop ((level, hdr, fun () -> Tar.return (Ok None)) :: acc) rest
+          )
+    in
+    loop [] ((List.map Eio.Path.(( / ) src)) files)
+  in
+  Eio.Switch.run @@ fun sw ->
+  let entries = to_stream (dir_entry :: entries sw) in
+  let entries () = Tar.return (Ok (entries ())) in
+  fn @@ Tar.out ?level ?global_hdr:global entries

--- a/eio/tar_eio.ml
+++ b/eio/tar_eio.ml
@@ -19,6 +19,11 @@
 type decode_error =
   [ `Fatal of Tar.error | `Unexpected_end_of_file | `Msg of string ]
 
+let pp_decode_error ppf = function
+  | `Fatal err -> Tar.pp_error ppf err
+  | `Unexpected_end_of_file -> Fmt.string ppf "Unexpected end of file"
+  | `Msg s -> Fmt.pf ppf "Error %s" s
+
 let ( / ) = Eio.Path.( / )
 let ( let* ) = Result.bind
 let ( let+ ) v f = Result.map f v
@@ -41,11 +46,18 @@ type t = High.t
 
 let value v = Tar.High (High.inj v)
 
-type src = Flow : _ Eio.Flow.source -> src | File : _ Eio.File.ro -> src
+type flow = Flow : _ Eio.Flow.two_way -> flow | File : _ Eio.File.rw -> flow
 
-let src_to_flow = function
+let flow_of_two_way tw = Flow tw
+let flow_of_file f = File f
+
+let flow_to_source = function
   | Flow f -> (f :> Eio.Flow.source_ty Eio.Flow.source)
   | File f -> (f :> Eio.Flow.source_ty Eio.Flow.source)
+
+let flow_to_sink = function
+  | Flow f -> (f :> Eio.Flow.sink_ty Eio.Flow.sink)
+  | File f -> (f :> Eio.Flow.sink_ty Eio.Flow.sink)
 
 let skip f n =
   let buffer_size = 32768 in
@@ -62,9 +74,11 @@ let skip f n =
 
 let run t f =
   let rec run : type a. (a, 'err, t) Tar.t -> (a, 'err) result = function
-    | Tar.Write _ -> assert false
+    | Tar.Write s ->
+       Eio.Flow.copy_string s (flow_to_sink f);
+       Ok ()
     | Tar.Read len -> (
-        let f = src_to_flow f in
+        let f = flow_to_source f in
         let b = Cstruct.create len in
         match Eio.Flow.single_read f b with
         | len -> Ok (Cstruct.to_string ~len b)
@@ -72,7 +86,7 @@ let run t f =
             (* XXX: should we catch other exceptions?! *)
             Error `Unexpected_end_of_file)
     | Tar.Really_read len -> (
-        let f = src_to_flow f in
+        let f = flow_to_source f in
         let b = Cstruct.create len in
         try
           Eio.Flow.read_exact f b;

--- a/eio/tar_eio.ml
+++ b/eio/tar_eio.ml
@@ -75,8 +75,8 @@ let skip f n =
 let run t f =
   let rec run : type a. (a, 'err, t) Tar.t -> (a, 'err) result = function
     | Tar.Write s ->
-       Eio.Flow.copy_string s (flow_to_sink f);
-       Ok ()
+        Eio.Flow.copy_string s (flow_to_sink f);
+        Ok ()
     | Tar.Read len -> (
         let f = flow_to_source f in
         let b = Cstruct.create len in

--- a/eio/tar_eio.mli
+++ b/eio/tar_eio.mli
@@ -44,15 +44,16 @@ val pp_decode_error : decode_error Fmt.t
 
 val extract :
   ?filter:(Tar.Header.t -> bool) ->
+  sw:Eio.Switch.t ->
   Eio.Fs.dir_ty Eio.Path.t ->
-  ((unit, [> `Fatal of Tar.error ], t) Tar.t -> 'a) ->
-  'a
-(** [extract dst fn] produces a {! Tar.t} that will extract to [dst]. For
+  (unit, [> `Fatal of Tar.error ], t) Tar.t
+(** [extract ~sw dst] produces a {! Tar.t} that will extract to [dst]. For
     example:
 
     {[
     Eio.Path.with_open_out ~create:`Never foo_tar_gz @@ fun src ->
-    Tar_eio.extract (env#cwd / "foo.out") @@ fun t ->
+    Eio.Switch.run @@ fun sw ->
+    let t = Tar_eio.extract ~sw (env#cwd / "foo.out") in
     (* optional gzip: let t = Tar_gz.in_gzipped t in *)
     Tar_eio.run t (Tar_eio.flow_of_file src)
     ]}
@@ -63,8 +64,7 @@ val extract :
     the files according to the tar file).
 
     All operations, in particular the {! Tar_eio.run} must be completed inside
-    the scope of [fn] which ensures all resources are properly handled before
-    returning.
+    the scope of the {! Eio.Switch.t} [sw].
 
     @param filter Can be used to exclude certain entries based on their header.
 *)
@@ -73,10 +73,10 @@ val create :
   ?level:Tar.Header.compatibility ->
   ?global:Tar.Header.Extended.t ->
   ?filter:(Tar.Header.t -> bool) ->
+  sw:Eio.Switch.t ->
   _ Eio.Path.t ->
-  ((unit, [> `Msg of string ], 'b) Tar.t -> 'a) ->
-  'a
-(** [create dir @@ fun t -> ...] is the opposite of {! extract}. It returns a
+  (unit, [> `Msg of string ], 'b) Tar.t
+(** [create ~sw dir] is the opposite of {! extract}. It returns a
     {! Tar.t} of the supplied [dir] that is only valid for the scope of the
     function.
 
@@ -85,9 +85,9 @@ val create :
     {[
     let foo = Eio.Path.(cwd / "foo") in
     let foo_tar = Eio.Path.(cwd / "foo.tar") in
-    Eio.Path.with_open_out ~create:(`Or_truncate 0o755) foo_tar
-    @@ fun foo_tar ->
-    Tar_eio.create foo @@ fun t ->
+    Eio.Path.with_open_out ~create:(`Or_truncate 0o755) foo_tar @@ fun foo_tar ->
+    Eio.Switch.run @@ fun sw ->
+    let t = Tar_eio.create ~sw foo in
     Tar_eio.run t (Tar_eio.flow_of_file tar)
     ]}
 

--- a/eio/tar_eio.mli
+++ b/eio/tar_eio.mli
@@ -14,11 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(** {1 Eio Tar} 
+(** {1 Eio Tar}
 
-    This library provides low-level and high-level abstractions for reading
-    and writing Tar files using Eio.
-*)
+    This library provides low-level and high-level abstractions for reading and
+    writing Tar files using Eio. *)
 
 type t
 
@@ -26,13 +25,13 @@ type flow
 (** A type for reading or writing tar files to. *)
 
 val flow_of_two_way : _ Eio.Flow.two_way -> flow
-(** Construct a {! flow} from an {! Eio.Flow.two_way}. Use {! flow_of_file} if your
- flow is really a file. *)
+(** Construct a {! flow} from an {! Eio.Flow.two_way}. Use {! flow_of_file} if
+    your flow is really a file. *)
 
 val flow_of_file : _ Eio.File.rw -> flow
-(** Construct a {! flow} from an {! Eio.File.rw}. If you are using a file
-    it is best to use this function as the [seek] operations will be more
-    efficient. *)
+(** Construct a {! flow} from an {! Eio.File.rw}. If you are using a file it is
+    best to use this function as the [seek] operations will be more efficient.
+*)
 
 type decode_error =
   [ `Fatal of Tar.error | `Unexpected_end_of_file | `Msg of string ]
@@ -55,15 +54,16 @@ val extract :
 (** [extract src dst] extracts the tar file from [src] into [dst]. For example:
 
     {[
-      Eio.Path.with_open_in src @@ fun src ->
-      Tar_eio.extract src dst
+    Eio.Path.with_open_in src @@ fun src -> Tar_eio.extract src dst
     ]}
 
-    will extract the file at [src] into the directory at [dst]. Note that this function
-    only creates {b files}, {b directories} and {b symlinks} with the correct mode (it does not, for
-    example, set the ownership of the files according to the tar file).
+    will extract the file at [src] into the directory at [dst]. Note that this
+    function only creates {b files}, {b directories} and {b symlinks} with the
+    correct mode (it does not, for example, set the ownership of the files
+    according to the tar file).
 
-    @param filter Can be used to exclude certain entries based on their header. *)
+    @param filter Can be used to exclude certain entries based on their header.
+*)
 
 val create :
   ?level:Tar.Header.compatibility ->
@@ -107,9 +107,10 @@ val header_of_file :
   ?getgrgid:(int64 -> string) ->
   Eio.Fs.dir_ty Eio.Path.t ->
   Tar.Header.t
-(** Return the header needed for a particular file on disk. [getpwuid] and [getgrgid] are optional
-    functions that should take the uid and gid respectively and return the passwd and group entry
-    names for each. These will be added to the header. *)
+(** Return the header needed for a particular file on disk. [getpwuid] and
+    [getgrgid] are optional functions that should take the uid and gid
+    respectively and return the passwd and group entry names for each. These
+    will be added to the header. *)
 
 val write_header :
   ?level:Tar.Header.compatibility ->

--- a/eio/tar_eio.mli
+++ b/eio/tar_eio.mli
@@ -22,23 +22,34 @@
 
 type t
 
-type src =
-  | Flow : _ Eio.Flow.source -> src
-  | File : _ Eio.File.ro -> src  (** Sources for tar files *)
+type flow
+(** A type for reading or writing tar files to. *)
+
+val flow_of_two_way : _ Eio.Flow.two_way -> flow
+(** Construct a {! flow} from an {! Eio.Flow.two_way}. Use {! flow_of_file} if your
+ flow is really a file. *)
+
+val flow_of_file : _ Eio.File.rw -> flow
+(** Construct a {! flow} from an {! Eio.File.rw}. If you are using a file
+    it is best to use this function as the [seek] operations will be more
+    efficient. *)
 
 type decode_error =
   [ `Fatal of Tar.error | `Unexpected_end_of_file | `Msg of string ]
 (** Possible decoding errors *)
 
+val pp_decode_error : decode_error Fmt.t
+(** A pretty-printer for decoding errors. *)
+
 (** {2 High-level Interface} *)
 
 val run :
-  ('a, ([> `Unexpected_end_of_file ] as 'b), t) Tar.t -> src -> ('a, 'b) result
+  ('a, ([> `Unexpected_end_of_file ] as 'b), t) Tar.t -> flow -> ('a, 'b) result
 (** [run tar src] will run the given [tar] using {! Eio} on [src]. *)
 
 val extract :
   ?filter:(Tar.Header.t -> bool) ->
-  src ->
+  flow ->
   Eio.Fs.dir_ty Eio.Path.t ->
   (unit, [> decode_error ]) result
 (** [extract src dst] extracts the tar file from [src] into [dst]. For example:
@@ -72,7 +83,7 @@ val fold :
   Tar.Header.t ->
   'acc ->
   ('acc, ([> `Fatal of Tar.error | `Unexpected_end_of_file ] as 'b), t) Tar.t) ->
-  src ->
+  flow ->
   'acc ->
   ('acc, 'b) result
 (** [fold f src init] folds over the tarred [src]. *)

--- a/eio/tar_eio.mli
+++ b/eio/tar_eio.mli
@@ -42,25 +42,29 @@ val pp_decode_error : decode_error Fmt.t
 
 (** {2 High-level Interface} *)
 
-val run :
-  ('a, ([> `Unexpected_end_of_file ] as 'b), t) Tar.t -> flow -> ('a, 'b) result
-(** [run tar src] will run the given [tar] using {! Eio} on [src]. *)
-
 val extract :
   ?filter:(Tar.Header.t -> bool) ->
-  flow ->
   Eio.Fs.dir_ty Eio.Path.t ->
-  (unit, [> decode_error ]) result
-(** [extract src dst] extracts the tar file from [src] into [dst]. For example:
+  ((unit, [> `Fatal of Tar.error ], t) Tar.t -> 'a) ->
+  'a
+(** [extract dst fn] produces a {! Tar.t} that will extract to [dst]. For
+    example:
 
     {[
-    Eio.Path.with_open_in src @@ fun src -> Tar_eio.extract src dst
+    Eio.Path.with_open_out ~create:`Never foo_tar_gz @@ fun src ->
+    Tar_eio.extract (env#cwd / "foo.out") @@ fun t ->
+    (* optional gzip: let t = Tar_gz.in_gzipped t in *)
+    Tar_eio.run t (Tar_eio.flow_of_file src)
     ]}
 
-    will extract the file at [src] into the directory at [dst]. Note that this
-    function only creates {b files}, {b directories} and {b symlinks} with the
-    correct mode (it does not, for example, set the ownership of the files
-    according to the tar file).
+    will extract the file at [foo_tar_gz] into the directory at ["foo.out"].
+    Note that this function only creates {b files}, {b directories} and
+    {b symlinks} with the correct mode (it does not, yet, set the ownership of
+    the files according to the tar file).
+
+    All operations, in particular the {! Tar_eio.run} must be completed inside
+    the scope of [fn] which ensures all resources are properly handled before
+    returning.
 
     @param filter Can be used to exclude certain entries based on their header.
 *)
@@ -69,14 +73,30 @@ val create :
   ?level:Tar.Header.compatibility ->
   ?global:Tar.Header.Extended.t ->
   ?filter:(Tar.Header.t -> bool) ->
-  src:Eio.Fs.dir_ty Eio.Path.t ->
-  _ Eio.Flow.sink ->
-  (unit, [> decode_error ]) result
-(** [create ~src dst] is the opposite of {! extract}. The path [src] is tarred
-    into [dst].
+  _ Eio.Path.t ->
+  ((unit, [> `Msg of string ], 'b) Tar.t -> 'a) ->
+  'a
+(** [create dir @@ fun t -> ...] is the opposite of {! extract}. It returns a
+    {! Tar.t} of the supplied [dir] that is only valid for the scope of the
+    function.
+
+    Common usage might be tarring a directory to a new file.
+
+    {[
+    let foo = Eio.Path.(cwd / "foo") in
+    let foo_tar = Eio.Path.(cwd / "foo.tar") in
+    Eio.Path.with_open_out ~create:(`Or_truncate 0o755) foo_tar
+    @@ fun foo_tar ->
+    Tar_eio.create foo @@ fun t ->
+    Tar_eio.run t (Tar_eio.flow_of_file tar)
+    ]}
 
     @param filter Can be used to exclude certain entries based on their header.
 *)
+
+val run :
+  ('a, ([> `Unexpected_end_of_file ] as 'b), t) Tar.t -> flow -> ('a, 'b) result
+(** [run tar src] will run the given [tar] using {! Eio} on [src]. *)
 
 val fold :
   (?global:Tar.Header.Extended.t ->

--- a/eio/test/dune
+++ b/eio/test/dune
@@ -1,0 +1,4 @@
+(test
+  (name test_eio)
+  (package tar-eio)
+  (libraries tar-eio tar.gz eio_main alcotest))

--- a/eio/test/test_eio.ml
+++ b/eio/test/test_eio.ml
@@ -1,0 +1,102 @@
+let ( / ) = Eio.Path.( / )
+let ( let* ) = Result.map
+let tar_eio_error = Alcotest.of_pp Tar_eio.pp_decode_error
+
+let stat =
+  let stat_equal (s1 : Eio.File.Stat.t) (s2 : Eio.File.Stat.t) =
+    s1.kind = s2.kind
+    && Optint.Int63.equal s1.size s2.size
+    && Int.equal s1.perm s2.perm
+  in
+  Alcotest.testable Eio.File.Stat.pp stat_equal
+
+let id =
+  let i = ref 0 in
+  fun () ->
+    incr i;
+    !i
+
+let with_tmp_dir cwd fn =
+  let tmp = cwd / Fmt.str "tmp-%i" (id ()) in
+  Eio.Path.mkdirs ~perm:0o755 tmp;
+  fn tmp
+
+let extra_error : [ Tar_gz.error | Tar_eio.decode_error ] Alcotest.testable =
+  let pp ppf = function
+    | `Gz e -> Fmt.pf ppf "gz %s" e
+    | `Eof -> Fmt.pf ppf "eof"
+    | #Tar_eio.decode_error as e -> Tar_eio.pp_decode_error ppf e
+  in
+  Alcotest.of_pp pp
+
+let test_e2e ?(filter_symlinks = false) ?(compress = false) cwd () =
+  let filter =
+    if filter_symlinks then fun (h : Tar.Header.t) ->
+      h.link_indicator <> Tar.Header.Link.Symbolic
+    else fun _ -> true
+  in
+  let test_tar = cwd / "test.tar" in
+  with_tmp_dir cwd @@ fun tmp ->
+  Eio.Path.save ~create:(`Or_truncate 0o755) (tmp / "hello.txt") "hello";
+  Eio.Path.save ~create:(`Or_truncate 0o755) (tmp / "world.txt") "world";
+  Eio.Path.symlink ~link_to:"hello.txt" (tmp / "hello-link.txt");
+  Eio.Path.mkdirs ~perm:0o600 (tmp / "hello");
+  let res =
+    Eio.Path.with_open_out ~create:(`Or_truncate 0o755) test_tar @@ fun out ->
+    Eio.Switch.run @@ fun sw ->
+    let t = Tar_eio.create ~filter ~sw tmp in
+    let t =
+      if compress then Tar_gz.out_gzipped ~level:4 ~mtime:0l Gz.Unix t else t
+    in
+    Tar_eio.run t (Tar_eio.flow_of_file out)
+  in
+  Alcotest.(check (result unit tar_eio_error)) "successful create" (Ok ()) res;
+  with_tmp_dir cwd @@ fun extract_dir ->
+  let res =
+    Eio.Switch.run @@ fun sw ->
+    let t = Tar_eio.extract ~sw extract_dir in
+    let t = if compress then Tar_gz.in_gzipped t else t in
+    Eio.Path.with_open_out ~create:`Never test_tar @@ fun src ->
+    Tar_eio.run t (Tar_eio.flow_of_file src)
+  in
+  Alcotest.(check (result unit extra_error)) "successful extract" (Ok ()) res;
+  let hello1, hello2 =
+    ( Eio.Path.stat ~follow:false (tmp / "hello.txt"),
+      Eio.Path.stat ~follow:false (extract_dir / snd tmp / "hello.txt") )
+  in
+  Alcotest.check stat "same hello.txt" hello1 hello2;
+  let hellod1, hellod2 =
+    ( Eio.Path.stat ~follow:false (tmp / "hello"),
+      Eio.Path.stat ~follow:false (extract_dir / snd tmp / "hello") )
+  in
+  Alcotest.check stat "same hello directory" hellod1 hellod2;
+  if filter_symlinks then begin
+    let symlink =
+      try
+        Some
+          (Eio.Path.stat ~follow:false
+             (extract_dir / snd tmp / "hello-link.txt"))
+      with Eio.Io (Eio.Fs.E (Not_found _), _) -> None
+    in
+    Alcotest.(check (option stat)) "no symlink" None symlink
+  end
+  else begin
+    let sym1, sym2 =
+      ( Eio.Path.stat ~follow:false (tmp / "hello-link.txt"),
+        Eio.Path.stat ~follow:false (extract_dir / snd tmp / "hello-link.txt")
+      )
+    in
+    Alcotest.check stat "same hello-link.txt" sym1 sym2
+  end
+
+let simple_tests cwd =
+  [
+    ("e2e", `Quick, test_e2e cwd);
+    ("e2e compression", `Quick, test_e2e ~compress:true cwd);
+    ("e2e filter syms", `Quick, test_e2e ~filter_symlinks:true cwd);
+  ]
+
+let () =
+  Eio_main.run @@ fun env ->
+  let cwd = Eio.Stdenv.cwd env in
+  Alcotest.run "tar-eio" [ ("simple", simple_tests cwd) ]

--- a/tar-eio.opam
+++ b/tar-eio.opam
@@ -24,6 +24,9 @@ depends: [
   "ocaml" {>= "5.00.0"}
   "eio" {>= "1.1"}
   "tar" {= version}
+  "eio_main" {with-test}
+  "alcotest" {with-test}
+  "decompress" {with-test}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This PR updates `tar-eio` to be much more useable and inline with the `tar.3.0.0` changes. I felt the same way as #165 and I'm hoping the API in `Tar_eio` will help Eio users.

This is a large breaking change to `tar-eio` but I don't think there are any published revdeps:

```
opam list --depends-on=tar-eio --recursive
# Packages matching: rec-depends-on(tar-eio) & (installed | available)
# Name          # Installed # Synopsis
tar-eio         3.3.0       Decode and encode tar format files using Eio
```

There are two main changes:

 1. `Tar_eio` now goes _all in_ on the `tar.3.0.0` API producing `Tar.t`s from the `create` and `extract` functions. Previously it had copied [what the lwt version does](https://github.com/mirage/ocaml-tar/blob/cde9c483f4e06e8200257b03d03ebcf3fd5993eb/unix/tar_lwt_unix.ml#L259), which is to half handroll a Tar implementation! It is nice to have _a lot_ of abstraction, but this pushed a lot of the onus on the user to get a lot of subtleties right about what the tar format expects (e.g. https://github.com/quantifyearth/container-image/blob/a0f5f894c2aa46c867b025276d68689532f110c6/src/checkout.ml#L44). By choosing to use the core Tar API for everything, I'm hoping that the resulting functions are more correct.
 2. `Tar_eio` used to only allow things that were a "src" and so the `Tar.Write` was stubbed out! This PR updates the `src` to be any `Eio.Flow.two_way`-like thing so things can now be extracted as well as created. To future proof this, the type is now abstract and we provided functions from generics flows and files.
 
Eio does not yet have support for some needed operations here but they can come later (e.g. https://github.com/ocaml-multicore/eio/pull/785).